### PR TITLE
feat: add `no-invalid-hex-color` css rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ export default [
 | :------------------------------------------------------------- | :-------------------------------- | :-------------: |
 | [`no-duplicate-imports`](./docs/rules/no-duplicate-imports.md) | Disallow duplicate @import rules. |       yes       |
 | [`no-empty-blocks`](./docs/rules/no-empty-blocks.md)           | Disallow empty blocks.            |       yes       |
+| [`no-invalid-hex-color`](./docs/rules/no-invalid-hex-color.md) | Disallow invalid hex color.       |       yes       |
 
 <!-- Rule Table End -->
 

--- a/docs/rules/no-invalid-hex-color.md
+++ b/docs/rules/no-invalid-hex-color.md
@@ -1,0 +1,51 @@
+# no-invalid-hex-color
+
+Disallows invalid hex color.
+
+## Background
+
+CSS hex colors can be of 3, 4, 6 or 8 hexadecimal characters. For example:
+
+```css
+a {
+	color: #000;
+}
+.box {
+	color: #000c;
+}
+#title {
+	color: #fefefe;
+}
+div {
+	color: #ffccbbee;
+}
+```
+
+## Rule Details
+
+This rule warns when it finds an invalid hex color in your css code.
+
+Examples of incorrect code:
+
+```css
+a {
+	color: #0000FZ;
+}
+
+div {
+	color: #0;
+}
+
+#title {
+	color: #ffxxzz;
+}
+
+.box {
+	color: #ab99001;
+}
+```
+
+## Prior Art
+
+-   [empty-rules](https://github.com/CSSLint/csslint/wiki/Disallow-empty-rules)
+-   [`block-no-empty`](https://stylelint.io/user-guide/rules/block-no-empty)

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ import { CSSLanguage } from "./languages/css-language.js";
 import { CSSSourceCode } from "./languages/css-source-code.js";
 import noEmptyBlocks from "./rules/no-empty-blocks.js";
 import noDuplicateImports from "./rules/no-duplicate-imports.js";
+import noInvalidHexColor from "./rules/no-invalid-hex-color.js";
 
 //-----------------------------------------------------------------------------
 // Plugin
@@ -27,6 +28,7 @@ const plugin = {
 	rules: {
 		"no-empty-blocks": noEmptyBlocks,
 		"no-duplicate-imports": noDuplicateImports,
+		"no-invalid-hex-color": noInvalidHexColor,
 	},
 	configs: {},
 };

--- a/src/index.js
+++ b/src/index.js
@@ -39,6 +39,7 @@ Object.assign(plugin.configs, {
 		rules: {
 			"css/no-empty-blocks": "error",
 			"css/no-duplicate-imports": "error",
+			"css/no-invalid-hex-color": "error",
 		},
 	},
 });

--- a/src/rules/no-invalid-hex-color.js
+++ b/src/rules/no-invalid-hex-color.js
@@ -1,0 +1,36 @@
+/**
+ * @fileoverview Rule to disallow invalid hex color
+ * @author Akul Srivastava
+ */
+
+const VALID_HEX_REGEX = /^(?:[\da-f]{3,4}|[\da-f]{6}|[\da-f]{8})$/iu;
+
+export default {
+	meta: {
+		type: "problem",
+
+		docs: {
+			description: "Disallow invalid hex color.",
+			recommended: true,
+		},
+
+		messages: {
+			invalidHexColor: "Invalid hex color found.",
+		},
+	},
+
+	create(context) {
+		return {
+			Hash(node) {
+				const hashValue = node.value;
+				const isValidHex = VALID_HEX_REGEX.test(hashValue);
+				if (!isValidHex) {
+					context.report({
+						loc: node.loc,
+						messageId: "invalidHexColor",
+					});
+				}
+			},
+		};
+	},
+};

--- a/tests/rules/no-invalid-hex-color.test.js
+++ b/tests/rules/no-invalid-hex-color.test.js
@@ -1,0 +1,82 @@
+/**
+ * @fileoverview Tests for invalid hex colors
+ * @author Akul Srivastava
+ */
+
+//------------------------------------------------------------------------------
+// Imports
+//------------------------------------------------------------------------------
+
+import rule from "../../src/rules/no-invalid-hex-color.js";
+import css from "../../src/index.js";
+import { RuleTester } from "eslint";
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+	plugins: {
+		css,
+	},
+	language: "css/css",
+});
+
+ruleTester.run("no-invalid-hex-color", rule, {
+	valid: [
+		{ code: "a { color: #0000FF }" },
+		{ code: "#title { color: #fff }" },
+		{ code: ".box { border: 1px solid #fcfcfc }" },
+		{ code: ".box { background: red; }" },
+	],
+	invalid: [
+		{
+			code: "a { color: #0000FZ }",
+			errors: [
+				{
+					messageId: "invalidHexColor",
+					line: 1,
+					column: 12,
+					endLine: 1,
+					endColumn: 19,
+				},
+			],
+		},
+		{
+			code: "a { color: #0 }",
+			errors: [
+				{
+					messageId: "invalidHexColor",
+					line: 1,
+					column: 12,
+					endLine: 1,
+					endColumn: 14,
+				},
+			],
+		},
+		{
+			code: "a { color: #ffxxzz }",
+			errors: [
+				{
+					messageId: "invalidHexColor",
+					line: 1,
+					column: 12,
+					endLine: 1,
+					endColumn: 19,
+				},
+			],
+		},
+		{
+			code: ".box { color: #ab99001 }",
+			errors: [
+				{
+					messageId: "invalidHexColor",
+					line: 1,
+					column: 15,
+					endLine: 1,
+					endColumn: 23,
+				},
+			],
+		},
+	],
+});


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Add `no-invalid-hex-color` css rule

#### What changes did you make? (Give an overview)

Add `no-invalid-hex-color` css rule, which warns when it finds an invalid hex color in your css code.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
