### PR TITLE
test: Ensure all rules are exported

### DIFF
--- a/tests/package/exports.js
+++ b/tests/package/exports.js
@@ -10,6 +10,18 @@
 import * as exports from "../../src/index.js";
 import assert from "node:assert";
 
+import path from "node:path";
+import fs from "node:fs/promises";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+//-----------------------------------------------------------------------------
+// Helpers
+//-----------------------------------------------------------------------------
+
+const filename = fileURLToPath(import.meta.url);
+const dirname = path.dirname(filename);
+const rulesDir = path.resolve(dirname, "../../src/rules");
+
 //------------------------------------------------------------------------------
 // Tests
 //------------------------------------------------------------------------------
@@ -22,6 +34,32 @@ describe("Package exports", () => {
 			"rules",
 			"configs",
 		]);
+	});
+
+	it("has all available rules exported in the ESLint plugin", async () => {
+		const allRules = (await fs.readdir(rulesDir))
+			.filter(name => name.endsWith(".js"))
+			.map(name => name.slice(0, -".js".length))
+			.sort();
+		const exportedRules = exports.default.rules;
+
+		assert.deepStrictEqual(
+			Object.keys(exportedRules).sort(),
+			allRules,
+			"Expected all rules to be exported in the ESLint plugin (`plugin.rules` in `src/index.js`)",
+		);
+
+		for (const [ruleName, rule] of Object.entries(exportedRules)) {
+			assert.strictEqual(
+				rule,
+				(
+					await import(
+						pathToFileURL(path.resolve(rulesDir, `${ruleName}.js`))
+					)
+				).default,
+				`Expected ${ruleName}.js to be exported under key "${ruleName}" in the ESLint plugin (\`plugin.rules\` in \`src/index.js\`)`,
+			);
+		}
 	});
 
 	it("has a CSSLanguage export", () => {

--- a/tests/plugin/eslint.test.js
+++ b/tests/plugin/eslint.test.js
@@ -18,6 +18,25 @@ import assert from "node:assert";
 //-----------------------------------------------------------------------------
 
 describe("Plugin", () => {
+	describe("Plugin configs", () => {
+		Object.keys(css.configs).forEach(configName => {
+			it(`Using "${configName}" config should not throw`, async () => {
+				const config = {
+					files: ["**/*.css"],
+					language: "css/css",
+					...css.configs[configName],
+				};
+
+				const eslint = new ESLint({
+					overrideConfigFile: true,
+					overrideConfig: config,
+				});
+
+				await eslint.lintText("div {}", { filePath: "test.css" });
+			});
+		});
+	});
+
 	describe("Configuration Comments", () => {
 		const config = {
 			files: ["*.css"],


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Ensures that all rules available in `src/rules` are exported in `plugin.rules`. Also adds a test for plugin configs that would fail if, for example, the config enables a non-existent rule.

#### What changes did you make? (Give an overview)

Added tests.

#### Related Issues

https://github.com/eslint/json/pull/53

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
