### PR TITLE
chore: use eslint-plugin-eslint-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,12 @@ export default [
 
 <!-- Rule Table Start -->
 
-| **Rule Name**                                                    | **Description**                   | **Recommended** |
-| :--------------------------------------------------------------- | :-------------------------------- | :-------------: |
-| [`no-duplicate-imports`](./docs/rules/no-duplicate-imports.md)   | Disallow duplicate @import rules. |       yes       |
-| [`no-empty-blocks`](./docs/rules/no-empty-blocks.md)             | Disallow empty blocks.            |       yes       |
-| [`no-invalid-properties`](./docs/rules/no-invalid-properties.md) | Disallow invalid properties.      |       yes       |
-| [`no-unknown-at-rules`](./docs/rules/no-unknown-at-rules.md)     | Disallow unknown at-rules.        |       yes       |
+| **Rule Name**                                                    | **Description**                  | **Recommended** |
+| :--------------------------------------------------------------- | :------------------------------- | :-------------: |
+| [`no-duplicate-imports`](./docs/rules/no-duplicate-imports.md)   | Disallow duplicate @import rules |       yes       |
+| [`no-empty-blocks`](./docs/rules/no-empty-blocks.md)             | Disallow empty blocks            |       yes       |
+| [`no-invalid-properties`](./docs/rules/no-invalid-properties.md) | Disallow invalid properties      |       yes       |
+| [`no-unknown-at-rules`](./docs/rules/no-unknown-at-rules.md)     | Disallow unknown at-rules        |       yes       |
 
 <!-- Rule Table End -->
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,6 +8,7 @@
 //-----------------------------------------------------------------------------
 
 import eslintConfigESLint from "eslint-config-eslint";
+import eslintPlugin from "eslint-plugin-eslint-plugin";
 import json from "@eslint/json";
 
 //-----------------------------------------------------------------------------
@@ -17,6 +18,11 @@ import json from "@eslint/json";
 const eslintPluginJSDoc = eslintConfigESLint.find(
 	config => config.plugins?.jsdoc,
 ).plugins.jsdoc;
+
+const eslintPluginRulesRecommendedConfig =
+	eslintPlugin.configs["flat/rules-recommended"];
+const eslintPluginTestsRecommendedConfig =
+	eslintPlugin.configs["flat/tests-recommended"];
 
 //-----------------------------------------------------------------------------
 // Configuration
@@ -66,6 +72,42 @@ export default [
 				before: "readonly",
 				after: "readonly",
 			},
+		},
+	},
+	{
+		files: ["src/rules/*.js"],
+		...eslintPluginRulesRecommendedConfig,
+		rules: {
+			...eslintPluginRulesRecommendedConfig.rules,
+			"eslint-plugin/require-meta-schema": "off", // `schema` defaults to []
+			"eslint-plugin/prefer-placeholders": "error",
+			"eslint-plugin/prefer-replace-text": "error",
+			"eslint-plugin/report-message-format": ["error", "[^a-z].*\\.$"],
+			"eslint-plugin/require-meta-docs-description": [
+				"error",
+				{ pattern: "^(Enforce|Require|Disallow) .+[^. ]$" },
+			],
+		},
+	},
+	{
+		files: ["tests/rules/*.test.js"],
+		...eslintPluginTestsRecommendedConfig,
+		rules: {
+			...eslintPluginTestsRecommendedConfig.rules,
+			"eslint-plugin/test-case-property-ordering": [
+				"error",
+				[
+					"name",
+					"filename",
+					"code",
+					"output",
+					"language",
+					"options",
+					"languageOptions",
+					"errors",
+				],
+			],
+			"eslint-plugin/test-case-shorthand-strings": "error",
 		},
 	},
 ];

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "dedent": "^1.5.3",
     "eslint": "^9.11.1",
     "eslint-config-eslint": "^11.0.0",
+    "eslint-plugin-eslint-plugin": "^6.3.2",
     "got": "^14.4.2",
     "lint-staged": "^15.2.7",
     "mdast-util-from-markdown": "^2.0.2",

--- a/src/rules/no-duplicate-imports.js
+++ b/src/rules/no-duplicate-imports.js
@@ -8,7 +8,7 @@ export default {
 		type: "problem",
 
 		docs: {
-			description: "Disallow duplicate @import rules.",
+			description: "Disallow duplicate @import rules",
 			recommended: true,
 		},
 

--- a/src/rules/no-empty-blocks.js
+++ b/src/rules/no-empty-blocks.js
@@ -8,7 +8,7 @@ export default {
 		type: "problem",
 
 		docs: {
-			description: "Disallow empty blocks.",
+			description: "Disallow empty blocks",
 			recommended: true,
 		},
 

--- a/src/rules/no-invalid-properties.js
+++ b/src/rules/no-invalid-properties.js
@@ -37,7 +37,7 @@ export default {
 		type: "problem",
 
 		docs: {
-			description: "Disallow invalid properties.",
+			description: "Disallow invalid properties",
 			recommended: true,
 		},
 

--- a/src/rules/no-unknown-at-rules.js
+++ b/src/rules/no-unknown-at-rules.js
@@ -24,7 +24,7 @@ export default {
 		type: "problem",
 
 		docs: {
-			description: "Disallow unknown at-rules.",
+			description: "Disallow unknown at-rules",
 			recommended: true,
 		},
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Enables `eslint-plugin-eslint-plugin` for linting rules and rule tests.

#### What changes did you make? (Give an overview)

Added `eslint-plugin-eslint-plugin` dev dependency and enabled rules in the eslint config.

Also removed the ending dot from `meta.docs.description` in rules.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->

Config is the same as in eslint/json repo (https://github.com/eslint/json/pull/64).