### PR TITLE
chore: add link to docs in each eslint rule

### DIFF
--- a/src/rules/no-duplicate-imports.js
+++ b/src/rules/no-duplicate-imports.js
@@ -10,6 +10,7 @@ export default {
 		docs: {
 			description: "Disallow duplicate @import rules",
 			recommended: true,
+			url: "https://github.com/eslint/css/blob/main/docs/rules/no-duplicate-imports.md",
 		},
 
 		messages: {

--- a/src/rules/no-empty-blocks.js
+++ b/src/rules/no-empty-blocks.js
@@ -10,6 +10,7 @@ export default {
 		docs: {
 			description: "Disallow empty blocks",
 			recommended: true,
+			url: "https://github.com/eslint/css/blob/main/docs/rules/no-empty-blocks.md",
 		},
 
 		messages: {

--- a/src/rules/no-invalid-at-rules.js
+++ b/src/rules/no-invalid-at-rules.js
@@ -49,6 +49,7 @@ export default {
 		docs: {
 			description: "Disallow invalid at-rules",
 			recommended: true,
+			url: "https://github.com/eslint/css/blob/main/docs/rules/no-invalid-at-rules.md",
 		},
 
 		messages: {

--- a/src/rules/no-invalid-properties.js
+++ b/src/rules/no-invalid-properties.js
@@ -21,6 +21,7 @@ export default {
 		docs: {
 			description: "Disallow invalid properties",
 			recommended: true,
+			url: "https://github.com/eslint/css/blob/main/docs/rules/no-invalid-properties.md",
 		},
 
 		messages: {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Improve the DX, particularly because many people expect eslint to only lint JS files. So making the docs easily accessible is important.

#### What changes did you make? (Give an overview)

Add [`docs.url`](https://eslint.org/docs/latest/extend/custom-rules#url) to every rule, so that you can click on the rule in your IDE to go directly to the documentation

#### Related Issues

&shy;-

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

&shy;-

<!-- markdownlint-disable-file MD004 -->
