### PR TITLE
feat: Add tolerant parsing mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,31 @@ export default [
 ];
 ```
 
+By default, the CSS parser runs in strict mode, which reports all parsing errors. If you'd like to allow recoverable parsing errors (those that the browser automatically fixes on its own), you can set the `tolerant` option to `true`:
+
+```js
+// eslint.config.js
+import css from "@eslint/css";
+
+export default [
+	{
+		files: ["**/*.css"],
+		plugins: {
+			css,
+		},
+		language: "css/css",
+		languageOptions: {
+			tolerant: true,
+		},
+		rules: {
+			"css/no-empty-blocks": "error",
+		},
+	},
+];
+```
+
+Setting `tolerant` to `true` is necessary if you are using custom syntax, such as [PostCSS](https://postcss.org/) plugins, that aren't part of the standard CSS syntax.
+
 ## License
 
 Apache 2.0

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "css-tree": "^3.0.1"
   },
   "devDependencies": {
-    "@eslint/core": "^0.6.0",
+    "@eslint/core": "^0.7.0",
     "@eslint/json": "^0.5.0",
     "@types/eslint": "^8.56.10",
     "c8": "^9.1.0",

--- a/tests/languages/css-language.test.js
+++ b/tests/languages/css-language.test.js
@@ -38,7 +38,7 @@ describe("CSSLanguage", () => {
 			assert.strictEqual(result.ast.children[0].type, "Rule");
 		});
 
-		it("should return an error when parsing invalid CSS", () => {
+		it("should return an error when CSS has a recoverable error", () => {
 			const language = new CSSLanguage();
 			const result = language.parse({
 				body: "a { foo; bar: 1! }",
@@ -59,6 +59,19 @@ describe("CSSLanguage", () => {
 			);
 			assert.strictEqual(result.errors[1].line, 1);
 			assert.strictEqual(result.errors[1].column, 18);
+		});
+
+		it("should not return an error when CSS has a recoverable error and tolerant: true is used", () => {
+			const language = new CSSLanguage();
+			const result = language.parse(
+				{
+					body: "a { foo; bar: 1! }",
+					path: "test.css",
+				},
+				{ languageOptions: { tolerant: true } },
+			);
+
+			assert.strictEqual(result.ok, true);
 		});
 
 		// https://github.com/csstree/csstree/issues/301

--- a/tests/plugin/eslint.test.js
+++ b/tests/plugin/eslint.test.js
@@ -37,6 +37,72 @@ describe("Plugin", () => {
 		});
 	});
 
+	describe("languageOptions", () => {
+		const config = {
+			files: ["*.css"],
+			plugins: {
+				css,
+			},
+			language: "css/css",
+			rules: {
+				"css/no-empty-blocks": "error",
+			},
+		};
+
+		describe("tolerant", () => {
+			it("should not report a parsing error when CSS has a recoverable error and tolerant: true is used", async () => {
+				const code = "a { foo; bar: 1! }";
+
+				const eslint = new ESLint({
+					overrideConfigFile: true,
+					overrideConfig: {
+						...config,
+						languageOptions: {
+							tolerant: true,
+						},
+					},
+				});
+
+				const results = await eslint.lintText(code, {
+					filePath: "test.css",
+				});
+
+				assert.strictEqual(results.length, 1);
+				assert.strictEqual(results[0].messages.length, 0);
+			});
+
+			it("should report a parsing error when CSS has a recoverable error and tolerant is undefined", async () => {
+				const code = "a { foo; bar: 1! }";
+
+				const eslint = new ESLint({
+					overrideConfigFile: true,
+					overrideConfig: config,
+				});
+
+				const results = await eslint.lintText(code, {
+					filePath: "test.css",
+				});
+
+				assert.strictEqual(results.length, 1);
+				assert.strictEqual(results[0].messages.length, 2);
+
+				assert.strictEqual(
+					results[0].messages[0].message,
+					"Parsing error: Colon is expected",
+				);
+				assert.strictEqual(results[0].messages[0].line, 1);
+				assert.strictEqual(results[0].messages[0].column, 8);
+
+				assert.strictEqual(
+					results[0].messages[1].message,
+					"Parsing error: Identifier is expected",
+				);
+				assert.strictEqual(results[0].messages[1].line, 1);
+				assert.strictEqual(results[0].messages[1].column, 18);
+			});
+		});
+	});
+
 	describe("Configuration Comments", () => {
 		const config = {
 			files: ["*.css"],


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Add a tolerant parsing mode.

#### What changes did you make? (Give an overview)

- Updated `CSSLanguage` to contain `defaultLanguageOptions` and `validateLanguageOptions()`
- Updated `CSSLanguage#parse()` to accept language options
- Updated tests
- Upgraded `@eslint/core` to v0.7.0 (not the latest, for best compatibility)

#### Related Issues

fixes #29


<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
