### PR TITLE
feat: Allow custom syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ export default [
 ];
 ```
 
+#### Tolerant Mode
+
 By default, the CSS parser runs in strict mode, which reports all parsing errors. If you'd like to allow recoverable parsing errors (those that the browser automatically fixes on its own), you can set the `tolerant` option to `true`:
 
 ```js
@@ -157,6 +159,73 @@ export default [
 ```
 
 Setting `tolerant` to `true` is necessary if you are using custom syntax, such as [PostCSS](https://postcss.org/) plugins, that aren't part of the standard CSS syntax.
+
+#### Configuring Custom Syntax
+
+The CSS lexer comes prebuilt with a set of known syntax for CSS that is used in rules like `no-invalid-properties` to validate CSS code. While this works for most cases, there may be cases when you want to define your own extensions to CSS, and this can be done using the `customSyntax` language option.
+
+The `customSyntax` option is an object that uses the [CSSTree format](https://github.com/csstree/csstree/blob/master/data/patch.json) for defining custom syntax, which allows you to specify at-rules, properties, and some types. For example, suppose you'd like to define a custom at-rule that looks like this:
+
+```css
+@my-at-rule "hello world!";
+```
+
+You can configure that syntax as follows:
+
+```js
+// eslint.config.js
+import css from "@eslint/css";
+
+export default [
+	{
+		files: ["**/*.css"],
+		plugins: {
+			css,
+		},
+		language: "css/css",
+		languageOptions: {
+			customSyntax: {
+				atrules: {
+					"my-at-rule": {
+						prelude: "<string>",
+					},
+				},
+			},
+		},
+		rules: {
+			"css/no-empty-blocks": "error",
+		},
+	},
+];
+```
+
+#### Configuring Tailwind Syntax
+
+[Tailwind](https://tailwindcss.com) specifies some extensions to CSS that will otherwise be flagged as invalid by the rules in this plugin. You can configure most of the custom syntax for Tailwind using the builtin `tailwindSyntax` object, like this:
+
+```js
+// eslint.config.js
+import css from "@eslint/css";
+import { tailwindSyntax } from "@eslint/css/syntax";
+
+export default [
+	{
+		files: ["**/*.css"],
+		plugins: {
+			css,
+		},
+		language: "css/css",
+		languageOptions: {
+			customSyntax: tailwindSyntax,
+		},
+		rules: {
+			"css/no-empty-blocks": "error",
+		},
+	},
+];
+```
+
+**Note:** The Tailwind syntax doesn't currently provide for the `theme()` function. This is a [limitation of CSSTree](https://github.com/csstree/csstree/issues/292) that we hope will be resolved soon.
 
 ## License
 

--- a/jsr.json
+++ b/jsr.json
@@ -1,11 +1,15 @@
 {
   "name": "@eslint/css",
   "version": "0.2.0",
-  "exports": "./dist/esm/index.js",
+  "exports": {
+    ".": "./dist/esm/index.js",
+    "./syntax": "./dist/esm/syntax/index.js"
+  },
   "publish": {
     "include": [
       "dist/esm/index.js",
       "dist/esm/index.d.ts",
+      "dist/esm/syntax/index.js",
       "README.md",
       "jsr.json",
       "LICENSE"

--- a/package.json
+++ b/package.json
@@ -7,13 +7,25 @@
   "main": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",
   "exports": {
-    "require": {
-      "types": "./dist/cjs/index.d.cts",
-      "default": "./dist/cjs/index.cjs"
+    ".": {
+      "require": {
+        "types": "./dist/cjs/index.d.cts",
+        "default": "./dist/cjs/index.cjs"
+      },
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      }
     },
-    "import": {
-      "types": "./dist/esm/index.d.ts",
-      "default": "./dist/esm/index.js"
+    "./syntax": {
+      "require": {
+        "types": "./dist/cjs/syntax/index.d.cts",
+        "default": "./dist/cjs/syntax/index.cjs"
+      },
+      "import": {
+        "types": "./dist/esm/syntax/index.d.ts",
+        "default": "./dist/esm/syntax/index.js"
+      }
     }
   },
   "files": [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,14 +1,30 @@
-export default {
-	input: "src/index.js",
-	output: [
-		{
-			file: "dist/cjs/index.cjs",
-			format: "cjs",
-		},
-		{
-			file: "dist/esm/index.js",
-			format: "esm",
-			banner: '// @ts-self-types="./index.d.ts"',
-		},
-	],
-};
+export default [
+	{
+		input: "src/index.js",
+		output: [
+			{
+				file: "dist/cjs/index.cjs",
+				format: "cjs",
+			},
+			{
+				file: "dist/esm/index.js",
+				format: "esm",
+				banner: '// @ts-self-types="./index.d.ts"',
+			},
+		],
+	},
+	{
+		input: "src/syntax/index.js",
+		output: [
+			{
+				file: "dist/cjs/syntax/index.cjs",
+				format: "cjs",
+			},
+			{
+				file: "dist/esm/syntax/index.js",
+				format: "esm",
+				banner: '// @ts-self-types="./index.d.ts"',
+			},
+		],
+	},
+];

--- a/src/languages/css-source-code.js
+++ b/src/languages/css-source-code.js
@@ -23,6 +23,7 @@ import { visitorKeys } from "./css-visitor-keys.js";
 /** @typedef {import("css-tree").CssNodePlain} CssNodePlain */
 /** @typedef {import("css-tree").BlockPlain} BlockPlain */
 /** @typedef {import("css-tree").Comment} Comment */
+/** @typedef {import("css-tree").Lexer} Lexer */
 /** @typedef {import("@eslint/core").SourceRange} SourceRange */
 /** @typedef {import("@eslint/core").SourceLocation} SourceLocation */
 /** @typedef {import("@eslint/core").SourceLocationWithOffset} SourceLocationWithOffset */
@@ -106,16 +107,24 @@ export class CSSSourceCode extends TextSourceCodeBase {
 	comments;
 
 	/**
+	 * The lexer for this instance.
+	 * @type {Lexer}
+	 */
+	lexer;
+
+	/**
 	 * Creates a new instance.
 	 * @param {Object} options The options for the instance.
 	 * @param {string} options.text The source code text.
 	 * @param {CssNodePlain} options.ast The root AST node.
 	 * @param {Array<Comment>} options.comments The comment nodes in the source code.
+	 * @param {Lexer} options.lexer The lexer used to parse the source code.
 	 */
-	constructor({ text, ast, comments }) {
+	constructor({ text, ast, comments, lexer }) {
 		super({ text, ast });
 		this.ast = ast;
 		this.comments = comments;
+		this.lexer = lexer;
 	}
 
 	/**

--- a/src/rules/no-invalid-at-rules.js
+++ b/src/rules/no-invalid-at-rules.js
@@ -7,7 +7,6 @@
 // Imports
 //-----------------------------------------------------------------------------
 
-import { lexer } from "css-tree";
 import { isSyntaxMatchError } from "../util.js";
 
 //-----------------------------------------------------------------------------
@@ -68,6 +67,7 @@ export default {
 
 	create(context) {
 		const { sourceCode } = context;
+		const lexer = sourceCode.lexer;
 
 		return {
 			Atrule(node) {

--- a/src/rules/no-invalid-properties.js
+++ b/src/rules/no-invalid-properties.js
@@ -7,7 +7,6 @@
 // Imports
 //-----------------------------------------------------------------------------
 
-import { lexer } from "css-tree";
 import { isSyntaxMatchError } from "../util.js";
 
 //-----------------------------------------------------------------------------
@@ -32,6 +31,8 @@ export default {
 	},
 
 	create(context) {
+		const lexer = context.sourceCode.lexer;
+
 		return {
 			"Rule > Block > Declaration"(node) {
 				// don't validate custom properties

--- a/src/syntax/index.js
+++ b/src/syntax/index.js
@@ -1,0 +1,6 @@
+/**
+ * @fileoverview Common extended CSSTree syntax definitions.
+ * @author Nicholas C. Zakas
+ */
+
+export { default as tailwindSyntax } from "./tailwind-syntax.js";

--- a/src/syntax/tailwind-syntax.js
+++ b/src/syntax/tailwind-syntax.js
@@ -1,0 +1,35 @@
+/**
+ * @fileoverview CSSTree syntax for Tailwind CSS extensions.
+ * @author Nicholas C. Zakas
+ */
+
+/*
+ * NOTE: This file intentionally not (yet) distributed as part
+ * of the package. It's only used for testing purposes.
+ */
+
+export default {
+	atrules: {
+		apply: {
+			prelude: "<ident>+",
+		},
+		tailwind: {
+			prelude: "base | components | utilities",
+		},
+		config: {
+			prelude: "<string>",
+		},
+	},
+
+	/*
+	 * CSSTree doesn't currently support custom functions properly, so leaving
+	 * these out for now.
+	 * https://github.com/csstree/csstree/issues/292
+	 */
+	// types: {
+	// 	"tailwind-theme-base": "spacing | colors",
+	// 	"tailwind-theme-color": "<tailwind-theme-base> [ '.' [ <ident> | <integer> ] ]+",
+	// 	"tailwind-theme-name": "<tailwind-theme-color>",
+	// 	"tailwind-theme()": "theme( <tailwind-theme-name>)",
+	// },
+};

--- a/tests/rules/no-invalid-at-rules.test.js
+++ b/tests/rules/no-invalid-at-rules.test.js
@@ -9,6 +9,7 @@
 
 import rule from "../../src/rules/no-invalid-at-rules.js";
 import css from "../../src/index.js";
+import tailwindSyntax from "../../src/syntax/tailwind-syntax.js";
 import { RuleTester } from "eslint";
 
 //------------------------------------------------------------------------------
@@ -30,6 +31,42 @@ ruleTester.run("no-invalid-at-rules", rule, {
 		"@supports (display: grid) { .grid-container { display: grid; } }",
 		"@namespace url(http://www.w3.org/1999/xhtml);",
 		"@media screen and (max-width: 600px) { body { font-size: 12px; } }",
+		{
+			code: "@foobar url(foo.css) { body { font-size: 12px } }",
+			languageOptions: {
+				customSyntax: {
+					atrules: {
+						foobar: {
+							prelude: "<url>",
+						},
+					},
+				},
+			},
+		},
+		{
+			code: "@tailwind base; @tailwind components; @tailwind utilities;",
+			languageOptions: {
+				customSyntax: tailwindSyntax,
+			},
+		},
+		{
+			code: "a { @apply text-red-500; }",
+			languageOptions: {
+				customSyntax: tailwindSyntax,
+			},
+		},
+		{
+			code: "a { @apply text-red-500 bg-blue-500; }",
+			languageOptions: {
+				customSyntax: tailwindSyntax,
+			},
+		},
+		{
+			code: "@config 'tailwind.config.js';",
+			languageOptions: {
+				customSyntax: tailwindSyntax,
+			},
+		},
 	],
 	invalid: [
 		{
@@ -162,6 +199,68 @@ ruleTester.run("no-invalid-at-rules", rule, {
 					column: 1,
 					endLine: 1,
 					endColumn: 11,
+				},
+			],
+		},
+		{
+			code: "@foobar { body { font-size: 12px } }",
+			languageOptions: {
+				customSyntax: {
+					atrules: {
+						foobar: {
+							prelude: "<url>",
+						},
+					},
+				},
+			},
+			errors: [
+				{
+					messageId: "missingPrelude",
+					data: { name: "foobar" },
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 8,
+				},
+			],
+		},
+		{
+			code: "a { @apply; }",
+			languageOptions: {
+				customSyntax: tailwindSyntax,
+			},
+			errors: [
+				{
+					messageId: "missingPrelude",
+					data: {
+						name: "apply",
+						prelude: "",
+						expected: "<ident>+",
+					},
+					line: 1,
+					column: 5,
+					endLine: 1,
+					endColumn: 11,
+				},
+			],
+		},
+		{
+			code: "@config;",
+			languageOptions: {
+				customSyntax: tailwindSyntax,
+			},
+			errors: [
+				{
+					messageId: "missingPrelude",
+					data: {
+						name: "config",
+						prelude: "",
+						expected: "<string>",
+					},
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 8,
 				},
 			],
 		},

--- a/tests/rules/no-invalid-properties.test.js
+++ b/tests/rules/no-invalid-properties.test.js
@@ -33,6 +33,33 @@ ruleTester.run("no-invalid-properties", rule, {
 		"@font-face { font-weight: 100 400 }",
 		'@property --foo { syntax: "*"; inherits: false; }',
 		"a { --my-color: red; color: var(--my-color) }",
+		{
+			code: "a { my-custom-color: red; }",
+			languageOptions: {
+				customSyntax: {
+					properties: {
+						"my-custom-color": "<color>",
+					},
+				},
+			},
+		},
+
+		/*
+		 * CSSTree doesn't currently support custom functions properly, so leaving
+		 * these out for now.
+		 * https://github.com/csstree/csstree/issues/292
+		 */
+		// {
+		// 	code: "a { my-custom-color: theme(colors.red); }",
+		// 	languageOptions: {
+		// 		customSyntax: {
+		// 			properties: {
+		// 				"my-custom-color": "<color> | <tailwind-theme()>",
+		// 			},
+		// 			types: tailwindSyntax.types,
+		// 		},
+		// 	},
+		// },
 	],
 	invalid: [
 		{
@@ -175,6 +202,30 @@ ruleTester.run("no-invalid-properties", rule, {
 					column: 5,
 					endLine: 1,
 					endColumn: 13,
+				},
+			],
+		},
+		{
+			code: "a { my-custom-color: solid; }",
+			languageOptions: {
+				customSyntax: {
+					properties: {
+						"my-custom-color": "<color>",
+					},
+				},
+			},
+			errors: [
+				{
+					messageId: "invalidPropertyValue",
+					data: {
+						property: "my-custom-color",
+						value: "solid",
+						expected: "<color>",
+					},
+					line: 1,
+					column: 22,
+					endLine: 1,
+					endColumn: 27,
 				},
 			],
 		},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Adds support for custom syntax to the parser.

#### What changes did you make? (Give an overview)

- Added `languageOptions.customSyntax` to `CSSLanguage`
- Updated rules to use custom syntax
- Updated tests for `CSSLanguage` and rules
- Updated README
- Added `/syntax` entrypoint for common custom syntax like Tailwind

#### Related Issues

fixes #37

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

There is a limitation in CSSTree that prevents custom functions like Tailwind's `theme()` to work properly, so I left that out:
https://github.com/csstree/csstree/issues/292

When that issue is resolved, we can revisit.


<!-- markdownlint-disable-file MD004 -->
