### PR TITLE
ci: add package manager install checks

### DIFF
--- a/.github/workflows/ci-build-all-pm.yml
+++ b/.github/workflows/ci-build-all-pm.yml
@@ -25,7 +25,7 @@ jobs:
             - run: npm pack
             - uses: actions/upload-artifact@v4
               with:
-                  name: build.zip
+                  name: build
                   path: eslint-css-*.tgz
                   retention-days: 1
             - name: Get version
@@ -38,7 +38,7 @@ jobs:
         steps:
             - uses: actions/download-artifact@v4
               with:
-                  name: build.zip
+                  name: build
             - name: npm install
               run: |
                   npm install ./eslint-css-${{ needs.npm-build.outputs.version }}.tgz -D
@@ -50,7 +50,7 @@ jobs:
         steps:
             - uses: actions/download-artifact@v4
               with:
-                  name: build.zip
+                  name: build
             - name: yarn add
               run: |
                   yarn add ./eslint-css-${{ needs.npm-build.outputs.version }}.tgz -D
@@ -61,7 +61,7 @@ jobs:
         steps:
             - uses: actions/download-artifact@v4
               with:
-                  name: build.zip
+                  name: build
             - name: Setup Node.js
               uses: actions/setup-node@v4
               with:
@@ -82,7 +82,7 @@ jobs:
         steps:
             - uses: actions/download-artifact@v4
               with:
-                  name: build.zip
+                  name: build
             - name: Setup Node.js
               uses: actions/setup-node@v4
               with:
@@ -103,7 +103,7 @@ jobs:
         steps:
             - uses: actions/download-artifact@v4
               with:
-                  name: build.zip
+                  name: build
             - name: setup bun
               uses: oven-sh/setup-bun@v2
             - name: bun install

--- a/.github/workflows/ci-build-all-pm.yml
+++ b/.github/workflows/ci-build-all-pm.yml
@@ -1,0 +1,111 @@
+name: CI Build install
+# This workflow creates a tarball from repo sources
+# It then checks that each of the following package managers is able to install:
+# - npm
+# - Yarn v1 Classic
+# - Yarn (Modern)
+# - pnpm
+# - bun
+on:
+    push:
+        branches:
+            - main
+    pull_request:
+        branches:
+            - main
+    workflow_dispatch:
+jobs:
+    npm-build:
+        name: Build tarball
+        runs-on: ubuntu-latest
+        outputs:
+            version: ${{ steps.get_version.outputs.version }}
+        steps:
+            - uses: actions/checkout@v4
+            - run: npm pack
+            - uses: actions/upload-artifact@v4
+              with:
+                  name: build.zip
+                  path: eslint-css-*.tgz
+                  retention-days: 1
+            - name: Get version
+              id: get_version
+              run: echo "version=$(jq -r '.version' package.json)" >> "$GITHUB_OUTPUT"
+    npm-install:
+        name: Install with npm
+        needs: npm-build
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/download-artifact@v4
+              with:
+                  name: build.zip
+            - name: npm install
+              run: |
+                  npm install ./eslint-css-${{ needs.npm-build.outputs.version }}.tgz -D
+    yarn-v1-install:
+        name: Install with Yarn v1
+        if: false # disable due to https://github.com/eslint/css/issues/58
+        needs: npm-build
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/download-artifact@v4
+              with:
+                  name: build.zip
+            - name: yarn add
+              run: |
+                  yarn add ./eslint-css-${{ needs.npm-build.outputs.version }}.tgz -D
+    yarn-install:
+        name: Install with Yarn
+        needs: npm-build
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/download-artifact@v4
+              with:
+                  name: build.zip
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 22.14.0 # minimum for Corepack
+            - name: yarn add
+              run: |
+                  corepack enable yarn
+                  corepack use yarn@latest
+                  yarn init -p
+                  yarn add ./eslint-css-${{ needs.npm-build.outputs.version }}.tgz -D
+              env:
+                  YARN_ENABLE_IMMUTABLE_INSTALLS: 0 # Allow installs to modify lockfile
+    pnpm-install:
+        name: Install with pnpm
+        if: false # disable due to https://github.com/eslint/css/issues/56
+        needs: npm-build
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/download-artifact@v4
+              with:
+                  name: build.zip
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 22.14.0 # minimum for Corepack
+            - name: pnpm add
+              run: |
+                  corepack enable pnpm
+                  corepack use pnpm@latest
+                  cat > .npmrc <<EOT
+                  auto-install-peers=true
+                  node-linker=hoisted
+                  EOT
+                  pnpm add ./eslint-css-${{ needs.npm-build.outputs.version }}.tgz -D
+    bun-install:
+        name: Install with bun
+        needs: npm-build
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/download-artifact@v4
+              with:
+                  name: build.zip
+            - name: setup bun
+              uses: oven-sh/setup-bun@v2
+            - name: bun install
+              run: |
+                  bun install ./eslint-css-${{ needs.npm-build.outputs.version }}.tgz -D


### PR DESCRIPTION
#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?

Current CI checks do not include checking that the packaged version of the repo can be installed. This has allowed release of versions with installation regressions.

This PR adds a new workflow `ci-build-all-pm.yml` that fills the gap of checking the ability to install.

#### What changes did you make? (Give an overview)

A tarball is created from the repo package source using [npm pack](https://docs.npmjs.com/cli/v11/commands/npm-pack).

The tarball `eslint-css-<version>.tgz` is then used to install with each of the package manager instructions listed in the [README > Installation](https://github.com/eslint/css/blob/main/README.md#installation) section

```shell
npm install @eslint/css -D
yarn add @eslint/css -D
pnpm install @eslint/css -D
bun install @eslint/css -D
```

For Yarn, both [Yarn v1 Classic](https://classic.yarnpkg.com/) and [Yarn Modern](https://yarnpkg.com/) are tested.

#### Related Issues

The following issues are related:

- https://github.com/eslint/css/issues/56
- https://github.com/eslint/css/issues/58

Due to these issues the corresponding tests for Yarn v1 Classic and pnpm are disabled.

#### Is there anything you'd like reviewers to focus on?

The outcome of the above two issues will determine whether the disabled tests can be enabled.

<!-- markdownlint-disable-file MD004 -->
