### PR TITLE
ci: enable pm checks Yarn v1 and pnpm

### DIFF
--- a/.github/workflows/ci-build-all-pm.yml
+++ b/.github/workflows/ci-build-all-pm.yml
@@ -44,7 +44,6 @@ jobs:
                   npm install ./eslint-css-${{ needs.npm-build.outputs.version }}.tgz -D
     yarn-v1-install:
         name: Install with Yarn v1
-        if: false # disable due to https://github.com/eslint/css/issues/58
         needs: npm-build
         runs-on: ubuntu-latest
         steps:
@@ -76,7 +75,6 @@ jobs:
                   YARN_ENABLE_IMMUTABLE_INSTALLS: 0 # Allow installs to modify lockfile
     pnpm-install:
         name: Install with pnpm
-        if: false # disable due to https://github.com/eslint/css/issues/56
         needs: npm-build
         runs-on: ubuntu-latest
         steps:


### PR DESCRIPTION
#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?

Enable temporarily disabled CI package manager installation checks in [.github/workflows/ci-build-all-pm.yml](https://github.com/eslint/css/blob/main/.github/workflows/ci-build-all-pm.yml) for

- Yarn v1 Classic
- pnpm

which were not compatible with the use of the `file:` protocol in `package.json`. The problem was resolved by PR https://github.com/eslint/css/pull/83.

#### What changes did you make? (Give an overview)

In [.github/workflows/ci-build-all-pm.yml](https://github.com/eslint/css/blob/main/.github/workflows/ci-build-all-pm.yml), remove the lines which disabled the jobs:

- `yarn-v1-install`
- `pnpm-install`

#### Related Issues

Follows on from fixes to:

- https://github.com/eslint/css/issues/56
- https://github.com/eslint/css/issues/58

through PR:

- https://github.com/eslint/css/pull/83

#### Is there anything you'd like reviewers to focus on?

Check that the workflow [.github/workflows/ci-build-all-pm.yml](https://github.com/eslint/css/blob/main/.github/workflows/ci-build-all-pm.yml) succeeds.