### PR TITLE
feat: CSS nesting baseline support

### DIFF
--- a/src/rules/require-baseline.js
+++ b/src/rules/require-baseline.js
@@ -375,6 +375,11 @@ class BaselineAvailability {
 	 * @returns {boolean} `true` if the feature is supported, `false` if not.
 	 */
 	isSupported(encodedStatus) {
+		if (!encodedStatus) {
+			// if we don't know the status, assume it's supported
+			return true;
+		}
+
 		const parts = encodedStatus.split(":");
 		const status = Number(parts[0]);
 		const year = Number(parts[1] || NaN);
@@ -775,6 +780,24 @@ export default {
 						});
 					}
 				}
+			},
+
+			NestingSelector(node) {
+				// NestingSelector implies CSS nesting
+				const selector = "nesting";
+				const featureStatus = selectors.get(selector);
+				if (baselineAvailability.isSupported(featureStatus)) {
+					return;
+				}
+
+				context.report({
+					loc: node.loc,
+					messageId: "notBaselineSelector",
+					data: {
+						selector,
+						availability: baselineAvailability.availability,
+					},
+				});
 			},
 		};
 	},

--- a/tests/rules/require-baseline.test.js
+++ b/tests/rules/require-baseline.test.js
@@ -439,5 +439,26 @@ ruleTester.run("require-baseline", rule, {
 				},
 			],
 		},
+		{
+			code: `label {
+				& input {
+					border: blue 2px dashed;
+				}
+			}`,
+			options: [{ available: 2022 }],
+			errors: [
+				{
+					messageId: "notBaselineSelector",
+					data: {
+						selector: "nesting",
+						availability: 2022,
+					},
+					line: 2,
+					column: 5,
+					endLine: 2,
+					endColumn: 6,
+				},
+			],
+		},
 	],
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Add support for evaluating baseline support for CSS nesting

#### What changes did you make? (Give an overview)

- added a test for CSS nesting
- added a handler for the `NestingSelector` key that checks for `nesting` selector availability
- added a check to `isSupported` so unknown feature statuses are supported by default (if the `nesting` ID happens to change, the test will fail and there won't be a runtime error)

#### Related Issues

fixes #85 

#### Is there anything you'd like reviewers to focus on?

Should the `nesting` selector ID be saved as a constant somewhere, or is it ok to hard-code it in the `NestingSelector` handler?

<!-- markdownlint-disable-file MD004 -->
