### PR TITLE
fix: Don't check class names in require-baseline

### DIFF
--- a/src/rules/require-baseline.js
+++ b/src/rules/require-baseline.js
@@ -31,13 +31,6 @@ import { namedColors } from "../data/colors.js";
 // Helpers
 //-----------------------------------------------------------------------------
 
-const alwaysOkSelectorTypes = new Set([
-	"TypeSelector",
-	"IdSelector",
-	"ClassSelector",
-	"AttributeSelector",
-]);
-
 /**
  * Represents a property that is supported via @supports.
  */
@@ -742,54 +735,48 @@ export default {
 				}
 			},
 
-			Selector(node) {
-				for (const child of node.children) {
-					const selector = child.name;
+			"PseudoClassSelector,PseudoElementSelector"(node) {
+				const selector = node.name;
 
-					if (alwaysOkSelectorTypes.has(child.type)) {
-						continue;
+				if (!selectors.has(selector)) {
+					return;
+				}
+
+				// if the selector has been tested in a @supports rule, don't check it
+				if (supportsRules.hasSelector(selector)) {
+					return;
+				}
+
+				const featureStatus = selectors.get(selector);
+
+				if (!baselineAvailability.isSupported(featureStatus)) {
+					const loc = node.loc;
+
+					// some selectors are prefixed with the : or :: symbols
+					let prefixSymbolLength = 0;
+					if (node.type.startsWith("PseudoClass")) {
+						prefixSymbolLength = 1;
+					} else if (node.type.startsWith("PseudoElement")) {
+						prefixSymbolLength = 2;
 					}
 
-					if (!selectors.has(selector)) {
-						continue;
-					}
-
-					// if the selector has been tested in a @supports rule, don't check it
-					if (supportsRules.hasSelector(selector)) {
-						continue;
-					}
-
-					const featureStatus = selectors.get(selector);
-
-					if (!baselineAvailability.isSupported(featureStatus)) {
-						const loc = child.loc;
-
-						// some selectors are prefixed with the : or :: symbols
-						let prefixSymbolLength = 0;
-						if (child.type === "PseudoClassSelector") {
-							prefixSymbolLength = 1;
-						} else if (child.type === "PseudoElementSelector") {
-							prefixSymbolLength = 2;
-						}
-
-						context.report({
-							loc: {
-								start: loc.start,
-								end: {
-									line: loc.start.line,
-									column:
-										loc.start.column +
-										selector.length +
-										prefixSymbolLength,
-								},
+					context.report({
+						loc: {
+							start: loc.start,
+							end: {
+								line: loc.start.line,
+								column:
+									loc.start.column +
+									selector.length +
+									prefixSymbolLength,
 							},
-							messageId: "notBaselineSelector",
-							data: {
-								selector,
-								availability: baselineAvailability.availability,
-							},
-						});
-					}
+						},
+						messageId: "notBaselineSelector",
+						data: {
+							selector,
+							availability: baselineAvailability.availability,
+						},
+					});
 				}
 			},
 

--- a/src/rules/require-baseline.js
+++ b/src/rules/require-baseline.js
@@ -31,6 +31,13 @@ import { namedColors } from "../data/colors.js";
 // Helpers
 //-----------------------------------------------------------------------------
 
+const alwaysOkSelectorTypes = new Set([
+	"TypeSelector",
+	"IdSelector",
+	"ClassSelector",
+	"AttributeSelector",
+]);
+
 /**
  * Represents a property that is supported via @supports.
  */
@@ -738,6 +745,10 @@ export default {
 			Selector(node) {
 				for (const child of node.children) {
 					const selector = child.name;
+
+					if (alwaysOkSelectorTypes.has(child.type)) {
+						continue;
+					}
 
 					if (!selectors.has(selector)) {
 						continue;

--- a/tests/rules/require-baseline.test.js
+++ b/tests/rules/require-baseline.test.js
@@ -62,6 +62,7 @@ ruleTester.run("require-baseline", rule, {
 		}`,
 		"div { cursor: pointer; }",
 		"pre { overflow: auto; }",
+		".highlight, #highlight, highlight { color: red }",
 		{
 			code: `@property --foo {
 				syntax: "*";


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Fixes incorrect flagging of `highlight` class name in `require-basline`

#### What changes did you make? (Give an overview)

- Updated `require-baseline` to skip class, type, ID, and attribute selectors
- Added test to verify the change

#### Related Issues

fixes #91

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

Ping @rviscomi can you take a look at this to make sure I fixed it correctly?

<!-- markdownlint-disable-file MD004 -->
