### PR TITLE
ci: Use consistent Node.js LTS version in CI Build install workflow

### DIFF
--- a/.github/workflows/ci-build-all-pm.yml
+++ b/.github/workflows/ci-build-all-pm.yml
@@ -22,6 +22,10 @@ jobs:
             version: ${{ steps.get_version.outputs.version }}
         steps:
             - uses: actions/checkout@v4
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: "lts/*"
             - run: npm pack
             - uses: actions/upload-artifact@v4
               with:
@@ -39,6 +43,10 @@ jobs:
             - uses: actions/download-artifact@v4
               with:
                   name: build
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: "lts/*"
             - name: npm install
               run: |
                   npm install ./eslint-css-${{ needs.npm-build.outputs.version }}.tgz -D
@@ -50,6 +58,10 @@ jobs:
             - uses: actions/download-artifact@v4
               with:
                   name: build
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: "lts/*"
             - name: yarn add
               run: |
                   yarn add ./eslint-css-${{ needs.npm-build.outputs.version }}.tgz -D
@@ -64,7 +76,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@v4
               with:
-                  node-version: 22.14.0 # minimum for Corepack
+                  node-version: "lts/*"
             - name: yarn add
               run: |
                   corepack enable yarn
@@ -84,7 +96,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@v4
               with:
-                  node-version: 22.14.0 # minimum for Corepack
+                  node-version: "lts/*"
             - name: pnpm add
               run: |
                   corepack enable pnpm
@@ -102,6 +114,10 @@ jobs:
             - uses: actions/download-artifact@v4
               with:
                   name: build
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: "lts/*"
             - name: setup bun
               uses: oven-sh/setup-bun@v2
             - name: bun install


### PR DESCRIPTION
#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?

Jobs in the workflow [.github/workflows/ci-build-all-pm.yml](https://github.com/eslint/css/blob/main/.github/workflows/ci-build-all-pm.yml) are using inconsistent versions of Node.js and do not align to the usage of Node.js LTS in the main [CI workflow](https://github.com/eslint/css/blob/main/.github/workflows/ci.yml) workflow.

The workflow is changed to used Node.js LTS consistently.

#### What changes did you make? (Give an overview)

Add [actions/setup-node@v4](https://github.com/actions/setup-node) to each job in [.github/workflows/ci-build-all-pm.yml](https://github.com/eslint/css/blob/main/.github/workflows/ci-build-all-pm.yml) where it is missing and set all jobs to use the Node.js Active LTS version.

#### Related Issues

- closes https://github.com/eslint/css/issues/98

#### Is there anything you'd like reviewers to focus on?

Check that https://github.com/eslint/css/actions/workflows/ci-build-all-pm.yml completes successfully
