### PR TITLE
docs: Add `use-baseline` URL

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -79,6 +79,13 @@ export default [
 		...eslintPluginRulesRecommendedConfig,
 		rules: {
 			...eslintPluginRulesRecommendedConfig.rules,
+			"eslint-plugin/require-meta-docs-url": [
+				"error",
+				{
+					pattern:
+						"https://github.com/eslint/css/blob/main/docs/rules/{{name}}.md",
+				},
+			],
 			"eslint-plugin/require-meta-schema": "off", // `schema` defaults to []
 			"eslint-plugin/prefer-placeholders": "error",
 			"eslint-plugin/prefer-replace-text": "error",

--- a/src/rules/use-baseline.js
+++ b/src/rules/use-baseline.js
@@ -403,6 +403,7 @@ export default {
 		docs: {
 			description: "Enforce the use of baseline features",
 			recommended: true,
+			url: "https://github.com/eslint/css/blob/main/docs/rules/use-baseline.md",
 		},
 
 		schema: [


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Adds `meta.docs.url` in the `use-baseline` rule.

#### What changes did you make? (Give an overview)

Added the URL and enabled `eslint-plugin/require-meta-docs-url` rule that would have caught this.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
