### PR TITLE
ci: use standalone Corepack for Yarn

### DIFF
--- a/.github/workflows/ci-build-all-pm.yml
+++ b/.github/workflows/ci-build-all-pm.yml
@@ -77,9 +77,12 @@ jobs:
               uses: actions/setup-node@v4
               with:
                   node-version: "lts/*"
+            - name: Install Corepack latest
+              run: |
+                  npm install -g corepack@latest
+                  corepack enable yarn
             - name: yarn add
               run: |
-                  corepack enable yarn
                   corepack use yarn@latest
                   yarn init -p
                   yarn add ./eslint-css-${{ needs.npm-build.outputs.version }}.tgz -D


### PR DESCRIPTION
#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?

The `yarn-install` job in the workflow [.github/workflows/ci-build-all-pm.yml](https://github.com/eslint/css/blob/main/.github/workflows/ci-build-all-pm.yml) relies on a version of Corepack bundled with Node.js. The Node.js website https://nodejs.org/docs/latest/api/corepack.html states "... Corepack itself will no longer be distributed with future versions of Node.js." which would cause the workflow to break.

[Yarn > Installation](https://yarnpkg.com/getting-started/install) now recommends using

```shell
npm install -g corepack
```

#### What changes did you make? (Give an overview)

In the workflow [.github/workflows/ci-build-all-pm.yml](https://github.com/eslint/css/blob/main/.github/workflows/ci-build-all-pm.yml), add `npm install -g corepack@latest` before using Corepack in the job `yarn-install`.

Note that although a global install of Corepack currently automatically enables Corepack, the explicit command to enable Corepack is retained in the workflow in case a future release of Corepack changes this undocumented default.

#### Related Issues

- contributes to closure of issue https://github.com/eslint/css/issues/104

#### Is there anything you'd like reviewers to focus on?

Check that https://github.com/eslint/css/actions/workflows/ci-build-all-pm.yml completes successfully
