### PR TITLE
ci: use pnpm/action-setup for pnpm

### DIFF
--- a/.github/workflows/ci-build-all-pm.yml
+++ b/.github/workflows/ci-build-all-pm.yml
@@ -93,14 +93,16 @@ jobs:
             - uses: actions/download-artifact@v4
               with:
                   name: build
+            - name: Install pnpm
+              uses: pnpm/action-setup@v4
+              with:
+                  version: latest
             - name: Setup Node.js
               uses: actions/setup-node@v4
               with:
                   node-version: "lts/*"
             - name: pnpm add
               run: |
-                  corepack enable pnpm
-                  corepack use pnpm@latest
                   cat > .npmrc <<EOT
                   auto-install-peers=true
                   node-linker=hoisted


### PR DESCRIPTION
#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?

The `pnpm-install` job in the workflow [.github/workflows/ci-build-all-pm.yml](https://github.com/eslint/css/blob/main/.github/workflows/ci-build-all-pm.yml) relies on a version of Corepack bundled with Node.js. The Node.js website https://nodejs.org/docs/latest/api/corepack.html states "... Corepack itself will no longer be distributed with future versions of Node.js." which would cause the workflow to break.

Following the pnpm package manager's documentation [Continuous Integration > GitHub Actions](https://pnpm.io/continuous-integration#github-actions), the installation method for pnpm in GitHub Actions is changed to using the JavaScript GitHub Action [pnpm/action-setup@v4](https://github.com/pnpm/action-setup), replacing the need for Corepack.

#### What changes did you make? (Give an overview)

In the workflow [.github/workflows/ci-build-all-pm.yml](https://github.com/eslint/css/blob/main/.github/workflows/ci-build-all-pm.yml) `pnpm-install` job, replace `corepack` with [pnpm/action-setup@v4](https://github.com/pnpm/action-setup) following the example in [Continuous Integration > GitHub Actions](https://pnpm.io/continuous-integration#github-actions).

#### Related Issues

- contributes to closing issue https://github.com/eslint/css/issues/104

#### Is there anything you'd like reviewers to focus on?

Check that https://github.com/eslint/css/actions/workflows/ci-build-all-pm.yml completes successfully

