### PR TITLE
fix: Set use-baseline to 'warn' in recommended config

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,7 @@ const plugin = {
 				"css/no-duplicate-imports": "error",
 				"css/no-invalid-at-rules": "error",
 				"css/no-invalid-properties": "error",
-				"css/use-baseline": "error",
+				"css/use-baseline": "warn",
 			}),
 		},
 	},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Sets the `use-baseline` rule to `"warn"` in the recommended config.

#### Related Issues

fixes #80


<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
