### PR TITLE
fix(types): add missing `Comment` type import

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,7 @@
 
 import type { RuleVisitor, RuleDefinition } from "@eslint/core";
 
-import type { CssNodePlain, CssNodeNames } from "@eslint/css-tree";
+import type { CssNodePlain, CssNodeNames, Comment } from "@eslint/css-tree";
 
 import type { CSSLanguageOptions, CSSSourceCode } from "./index.js";
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

To resolve https://github.com/eslint/css/issues/118.

#### What changes did you make? (Give an overview)

- Import the `Comment` type in `src/types.ts` from `@eslint/css-tree`.

#### Related Issues

Fixes https://github.com/eslint/css/issues/118.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
