### PR TITLE
docs: Update README to use defineConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ export default defineConfig([
 	{
 		files: ["**/*.css"],
 		language: "css/css",
-                plugins: { css },
+		plugins: { css },
 		extends: ["css/recommended"],
 	},
 

--- a/README.md
+++ b/README.md
@@ -36,18 +36,19 @@ In your `eslint.config.js` file, import `@eslint/css` and include the recommende
 
 ```js
 // eslint.config.js
+import { defineConfig } from "eslint/config";
 import css from "@eslint/css";
 
-export default [
+export default defineConfig([
 	// lint CSS files
 	{
 		files: ["**/*.css"],
 		language: "css/css",
-		...css.configs.recommended,
+		extends: ["css/recommended"],
 	},
 
 	// your other configs here
-];
+]);
 ```
 
 ### Rules
@@ -74,9 +75,10 @@ In order to individually configure a rule in your `eslint.config.js` file, impor
 
 ```js
 // eslint.config.js
+import { defineConfig } from "eslint/config";
 import css from "@eslint/css";
 
-export default [
+export default defineConfig([
 	{
 		files: ["**/*.css"],
 		plugins: {
@@ -87,7 +89,7 @@ export default [
 			"css/no-empty-blocks": "error",
 		},
 	},
-];
+]);
 ```
 
 You can individually config, disable, and enable rules in CSS using comments, such as:
@@ -119,9 +121,10 @@ In order to individually configure a language in your `eslint.config.js` file, i
 
 ```js
 // eslint.config.js
+import { defineConfig } from "eslint/config";
 import css from "@eslint/css";
 
-export default [
+export default defineConfig([
 	{
 		files: ["**/*.css"],
 		plugins: {
@@ -132,7 +135,7 @@ export default [
 			"css/no-empty-blocks": "error",
 		},
 	},
-];
+]);
 ```
 
 #### Tolerant Mode
@@ -141,9 +144,10 @@ By default, the CSS parser runs in strict mode, which reports all parsing errors
 
 ```js
 // eslint.config.js
+import { defineConfig } from "eslint/config";
 import css from "@eslint/css";
 
-export default [
+export default defineConfig([
 	{
 		files: ["**/*.css"],
 		plugins: {
@@ -157,7 +161,7 @@ export default [
 			"css/no-empty-blocks": "error",
 		},
 	},
-];
+]);
 ```
 
 Setting `tolerant` to `true` is necessary if you are using custom syntax, such as [PostCSS](https://postcss.org/) plugins, that aren't part of the standard CSS syntax.
@@ -176,9 +180,10 @@ You can configure that syntax as follows:
 
 ```js
 // eslint.config.js
+import { defineConfig } from "eslint/config";
 import css from "@eslint/css";
 
-export default [
+export default defineConfig([
 	{
 		files: ["**/*.css"],
 		plugins: {
@@ -198,7 +203,7 @@ export default [
 			"css/no-empty-blocks": "error",
 		},
 	},
-];
+]);
 ```
 
 #### Configuring Tailwind Syntax
@@ -207,10 +212,11 @@ export default [
 
 ```js
 // eslint.config.js
+import { defineConfig } from "eslint/config";
 import css from "@eslint/css";
 import { tailwindSyntax } from "@eslint/css/syntax";
 
-export default [
+export default defineConfig([
 	{
 		files: ["**/*.css"],
 		plugins: {
@@ -224,7 +230,7 @@ export default [
 			"css/no-empty-blocks": "error",
 		},
 	},
-];
+]);
 ```
 
 **Note:** The Tailwind syntax doesn't currently provide for the `theme()` function. This is a [limitation of CSSTree](https://github.com/csstree/csstree/issues/292) that we hope will be resolved soon.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ export default defineConfig([
 	{
 		files: ["**/*.css"],
 		language: "css/css",
+                plugins: { css },
 		extends: ["css/recommended"],
 	},
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Updates the README to use `defineConfig()` in examples.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
