### PR TITLE
ci: run tests in Node.js 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                node: [23.x, 22.x, 20.x, 18.x, "18.18.0"]
+                node: [24.x, 22.x, 20.x, 18.x, "18.18.0"]
                 include:
                     - os: windows-latest
                       node: "lts/*"


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Hello,

This PR is a follow-up to https://github.com/eslint/eslint/pull/19702.

I've updated the GitHub Actions CI workflow to include Node.js 24 in the test matrix and to remove the odd-numbered version, 23.

#### What changes did you make? (Give an overview)

I've updated the GitHub Actions CI workflow to include Node.js 24 in the test matrix and to remove the odd-numbered version, 23.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
