### PR TITLE
feat: allow custom descriptors in no-invalid-at-rules

### DIFF
--- a/src/rules/no-invalid-at-rules.js
+++ b/src/rules/no-invalid-at-rules.js
@@ -121,7 +121,6 @@ export default {
 			},
 
 			"AtRule > Block > Declaration"(node) {
-
 				// skip custom descriptors
 				if (node.property.startsWith("--")) {
 					return;

--- a/src/rules/no-invalid-at-rules.js
+++ b/src/rules/no-invalid-at-rules.js
@@ -121,6 +121,10 @@ export default {
 			},
 
 			"AtRule > Block > Declaration"(node) {
+				if (node.property.startsWith("--")) {
+					return;
+				}
+
 				// get at rule node
 				const atRule = /** @type {AtrulePlain} */ (
 					sourceCode.getParent(sourceCode.getParent(node))

--- a/src/rules/no-invalid-at-rules.js
+++ b/src/rules/no-invalid-at-rules.js
@@ -122,7 +122,7 @@ export default {
 
 			"AtRule > Block > Declaration"(node) {
 
-                                // skip custom descriptors
+				// skip custom descriptors
 				if (node.property.startsWith("--")) {
 					return;
 				}

--- a/src/rules/no-invalid-at-rules.js
+++ b/src/rules/no-invalid-at-rules.js
@@ -121,6 +121,8 @@ export default {
 			},
 
 			"AtRule > Block > Declaration"(node) {
+
+                                // skip custom descriptors
 				if (node.property.startsWith("--")) {
 					return;
 				}

--- a/tests/rules/no-invalid-at-rules.test.js
+++ b/tests/rules/no-invalid-at-rules.test.js
@@ -67,6 +67,19 @@ ruleTester.run("no-invalid-at-rules", rule, {
 				customSyntax: tailwindSyntax,
 			},
 		},
+		{
+			code: `@custom-rule {
+				--foo: red;
+				--bar: blue;
+			}`,
+			languageOptions: {
+				customSyntax: {
+					atrules: {
+						"custom-rule": {},
+					},
+				},
+			},
+		},
 	],
 	invalid: [
 		{


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This PR modifies the `no-invalid-at-rules` rule to allow custom descriptors in at-rules.

#### What changes did you make? (Give an overview)

Modified the `no-invalid-at-rules` rule to skip validation for any descriptor that starts with `--`

#### Related Issues

Closes #127

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
