### PR TITLE
feat: add `relative-font-units` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,16 +58,17 @@ export default defineConfig([
 
 <!-- Rule Table Start -->
 
-| **Rule Name**                                                            | **Description**                       | **Recommended** |
-| :----------------------------------------------------------------------- | :------------------------------------ | :-------------: |
-| [`no-duplicate-imports`](./docs/rules/no-duplicate-imports.md)           | Disallow duplicate @import rules      |       yes       |
-| [`no-empty-blocks`](./docs/rules/no-empty-blocks.md)                     | Disallow empty blocks                 |       yes       |
-| [`no-important`](./docs/rules/no-important.md)                           | Disallow !important flags             |       yes       |
-| [`no-invalid-at-rules`](./docs/rules/no-invalid-at-rules.md)             | Disallow invalid at-rules             |       yes       |
-| [`no-invalid-properties`](./docs/rules/no-invalid-properties.md)         | Disallow invalid properties           |       yes       |
-| [`prefer-logical-properties`](./docs/rules/prefer-logical-properties.md) | Enforce the use of logical properties |       no        |
-| [`use-baseline`](./docs/rules/use-baseline.md)                           | Enforce the use of baseline features  |       yes       |
-| [`use-layers`](./docs/rules/use-layers.md)                               | Require use of layers                 |       no        |
+| **Rule Name**                                                            | **Description**                        | **Recommended** |
+| :----------------------------------------------------------------------- | :------------------------------------- | :-------------: |
+| [`no-duplicate-imports`](./docs/rules/no-duplicate-imports.md)           | Disallow duplicate @import rules       |       yes       |
+| [`no-empty-blocks`](./docs/rules/no-empty-blocks.md)                     | Disallow empty blocks                  |       yes       |
+| [`no-important`](./docs/rules/no-important.md)                           | Disallow !important flags              |       yes       |
+| [`no-invalid-at-rules`](./docs/rules/no-invalid-at-rules.md)             | Disallow invalid at-rules              |       yes       |
+| [`no-invalid-properties`](./docs/rules/no-invalid-properties.md)         | Disallow invalid properties            |       yes       |
+| [`prefer-logical-properties`](./docs/rules/prefer-logical-properties.md) | Enforce the use of logical properties  |       no        |
+| [`relative-font-units`](./docs/rules/relative-font-units.md)             | Enforce the use of relative font units |       no        |
+| [`use-baseline`](./docs/rules/use-baseline.md)                           | Enforce the use of baseline features   |       yes       |
+| [`use-layers`](./docs/rules/use-layers.md)                               | Require use of layers                  |       no        |
 
 <!-- Rule Table End -->
 

--- a/docs/rules/relative-font-units.md
+++ b/docs/rules/relative-font-units.md
@@ -68,6 +68,10 @@ b {
 	font-size: 1rem;
 	width: 20px;
 }
+
+c {
+	font-size: var(--foo);
+}
 ```
 
 Font size can also be specified in `font` property:
@@ -84,8 +88,16 @@ b {
 		20% Arial,
 		sans-serif;
 }
+
+c {
+	font: Arial var(--foo);
+}
 ```
 
 ## When Not to Use It
 
 If your project does not prioritize the use of relative font-size units—such as in cases requiring absolute sizing for print styles, pixel-perfect UI components, or embedded widgets—you may safely disable this rule without impacting your intended design precision.
+
+## Prior Art
+
+- [`Surprising truth about Pixels and Accessibility`](https://www.joshwcomeau.com/css/surprising-truth-about-pixels-and-accessibility/)

--- a/docs/rules/relative-font-units.md
+++ b/docs/rules/relative-font-units.md
@@ -1,0 +1,91 @@
+# relative-font-units
+
+Enforce the use of relative units for font size.
+
+## Background
+
+The `font-size` property in CSS defines the size of the text. It can be set using:
+
+1. Keywords (e.g., small, medium, large).
+1. Length units (e.g., px, em, rem, pt).
+1. Percentages (%, relative to the parent element's font size).
+
+Generally, relative unit such as `rem` or `em` are preferred over absolute ones like `px`, `pt` because of following reasons:
+
+- **Responsive Design** - Relative units adapt better to various screen widths and pixel densities (e.g., mobile vs. desktop).
+- **Accessibility** - Relative units allow text to scale when users adjust browser settings or zoom levels.
+- **Consistency and Scalability** - Using relative units allow for consistent scaling across a whole site.
+- **Maintainability and Reusability** - Relative units allow components or utility classes to work well in different contexts.
+
+## Rule Detail
+
+This rule enforces the use of relative units for font size.
+
+### Options
+
+This rule accepts an option which is an object with following property:
+
+- `allow` (default: `["rem"]`) - Specify an array of relative units that are allowed to be used. You can use following units:
+
+    - **%**: Represents the "percentage" of the parent element’s font size, allowing the text to scale relative to its container.
+    - **cap**: Represents the "cap height" (nominal height of capital letters) of the element's font.
+    - **ch**: Represents the width or advance measure of the "0" glyph in the element's font.
+    - **em**: Represents the calculated font-size of the element.
+    - **ex**: Represents the x-height of the element's font.
+    - **ic**: Equal to the advance measure of the "水" glyph (CJK water ideograph) in the font.
+    - **lh**: Equal to the computed line-height of the element.
+    - **rcap**: Equal to the "cap height" of the root element's font.
+    - **rch**: Equal to the width or advance measure of the "0" glyph in the root element's font.
+    - **rem**: Represents the font-size of the root element.
+    - **rex**: Represents the x-height of the root element's font.
+    - **ric**: Equal to the ic unit on the root element's font.
+    - **rlh**: Equal to the lh unit on the root element's font.
+
+Example of **incorrect** code for default `{ allow: ["rem"] }` option:
+
+```css
+a {
+	font-size: 10px;
+}
+
+b {
+	font-size: 2em;
+}
+
+c {
+	font-size: small;
+}
+```
+
+Example of **correct** code for default `{ allow: ["rem"] }` option:
+
+```css
+a {
+	font-size: 2rem;
+}
+
+b {
+	font-size: 1rem;
+	width: 20px;
+}
+```
+
+Font size can also be specified in `font` property:
+
+Example of **correct** code for `{ allow: ["em", "%"] }` option:
+
+```css
+a {
+	font-size: 2em;
+}
+
+b {
+	font:
+		20% Arial,
+		sans-serif;
+}
+```
+
+## When Not to Use It
+
+If your project does not prioritize the use of relative font-size units—such as in cases requiring absolute sizing for print styles, pixel-perfect UI components, or embedded widgets—you may safely disable this rule without impacting your intended design precision.

--- a/docs/rules/relative-font-units.md
+++ b/docs/rules/relative-font-units.md
@@ -10,7 +10,7 @@ The `font-size` property in CSS defines the size of the text. It can be set usin
 1. Length units (e.g., `px`, `em`, `rem`, `pt`).
 1. Percentages (`%`, relative to the parent element's font size).
 
-Generally, relative unit such as `rem` or `em` are preferred over absolute ones like `px`, `pt` because of following reasons:
+Generally, relative units such as `rem` or `em` are preferred over absolute ones like `px`, `pt` because of the following reasons:
 
 - **Responsive Design** - Relative units adapt better to various screen widths and pixel densities (e.g., mobile vs. desktop).
 - **Accessibility** - Relative units allow text to scale when users adjust browser settings or zoom levels.
@@ -21,11 +21,11 @@ Generally, relative unit such as `rem` or `em` are preferred over absolute ones 
 
 This rule enforces the use of relative units for font size.
 
-### Options
+## Options
 
-This rule accepts an option which is an object with following property:
+This rule accepts an option which is an object with the following property:
 
-- `allow` (default: `["rem"]`) - Specify an array of relative units that are allowed to be used. You can use following units:
+- `allow` (default: `["rem"]`) - Specify an array of relative units that are allowed to be used. You can use the following units:
 
     - **%**: Represents the "percentage" of the parent element’s font size, allowing the text to scale relative to its container.
     - **cap**: Represents the "cap height" (nominal height of capital letters) of the element's font.
@@ -44,6 +44,8 @@ This rule accepts an option which is an object with following property:
 Example of **incorrect** code for default `{ allow: ["rem"] }` option:
 
 ```css
+/* eslint css/relative-font-units: ["error",  { allow: ["rem"] }] */
+
 a {
 	font-size: 10px;
 }
@@ -60,6 +62,8 @@ c {
 Example of **correct** code for default `{ allow: ["rem"] }` option:
 
 ```css
+/* eslint css/relative-font-units: ["error",  { allow: ["rem"] }] */
+
 a {
 	font-size: 2rem;
 }
@@ -79,6 +83,8 @@ Font size can also be specified in `font` property:
 Example of **correct** code for `{ allow: ["em", "%"] }` option:
 
 ```css
+/* eslint css/relative-font-units: ["error",  { allow: ["em", "%"] }] */
+
 a {
 	font-size: 2em;
 }

--- a/docs/rules/relative-font-units.md
+++ b/docs/rules/relative-font-units.md
@@ -25,7 +25,7 @@ This rule enforces the use of relative units for font size.
 
 This rule accepts an option which is an object with the following property:
 
-- `allow` (default: `["rem"]`) - Specify an array of relative units that are allowed to be used. You can use the following units:
+- `allowUnits` (default: `["rem"]`) - Specify an array of relative units that are allowed to be used. You can use the following units:
 
     - **%**: Represents the "percentage" of the parent element’s font size, allowing the text to scale relative to its container.
     - **cap**: Represents the "cap height" (nominal height of capital letters) of the element's font.
@@ -41,10 +41,10 @@ This rule accepts an option which is an object with the following property:
     - **ric**: Equal to the ic unit on the root element's font.
     - **rlh**: Equal to the lh unit on the root element's font.
 
-Example of **incorrect** code for default `{ allow: ["rem"] }` option:
+Example of **incorrect** code for default `{ allowUnits: ["rem"] }` option:
 
 ```css
-/* eslint css/relative-font-units: ["error",  { allow: ["rem"] }] */
+/* eslint css/relative-font-units: ["error",  { allowUnits: ["rem"] }] */
 
 a {
 	font-size: 10px;
@@ -59,10 +59,10 @@ c {
 }
 ```
 
-Example of **correct** code for default `{ allow: ["rem"] }` option:
+Example of **correct** code for default `{ allowUnits: ["rem"] }` option:
 
 ```css
-/* eslint css/relative-font-units: ["error",  { allow: ["rem"] }] */
+/* eslint css/relative-font-units: ["error",  { allowUnits: ["rem"] }] */
 
 a {
 	font-size: 2rem;
@@ -76,14 +76,18 @@ b {
 c {
 	font-size: var(--foo);
 }
+
+d {
+	font-size: calc(2rem + 2px);
+}
 ```
 
 Font size can also be specified in `font` property:
 
-Example of **correct** code for `{ allow: ["em", "%"] }` option:
+Example of **correct** code for `{ allowUnits: ["em", "%"] }` option:
 
 ```css
-/* eslint css/relative-font-units: ["error",  { allow: ["em", "%"] }] */
+/* eslint css/relative-font-units: ["error",  { allowUnits: ["em", "%"] }] */
 
 a {
 	font-size: 2em;

--- a/docs/rules/relative-font-units.md
+++ b/docs/rules/relative-font-units.md
@@ -6,9 +6,9 @@ Enforce the use of relative units for font size.
 
 The `font-size` property in CSS defines the size of the text. It can be set using:
 
-1. Keywords (e.g., small, medium, large).
-1. Length units (e.g., px, em, rem, pt).
-1. Percentages (%, relative to the parent element's font size).
+1. Keywords (e.g., `small`, `medium`, `large`).
+1. Length units (e.g., `px`, `em`, `rem`, `pt`).
+1. Percentages (`%`, relative to the parent element's font size).
 
 Generally, relative unit such as `rem` or `em` are preferred over absolute ones like `px`, `pt` because of following reasons:
 
@@ -17,7 +17,7 @@ Generally, relative unit such as `rem` or `em` are preferred over absolute ones 
 - **Consistency and Scalability** - Using relative units allow for consistent scaling across a whole site.
 - **Maintainability and Reusability** - Relative units allow components or utility classes to work well in different contexts.
 
-## Rule Detail
+## Rule Details
 
 This rule enforces the use of relative units for font size.
 
@@ -98,6 +98,6 @@ c {
 
 If your project does not prioritize the use of relative font-size units—such as in cases requiring absolute sizing for print styles, pixel-perfect UI components, or embedded widgets—you may safely disable this rule without impacting your intended design precision.
 
-## Prior Art
+## Further Reading
 
 - [`Surprising truth about Pixels and Accessibility`](https://www.joshwcomeau.com/css/surprising-truth-about-pixels-and-accessibility/)

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ import noImportant from "./rules/no-important.js";
 import noInvalidProperties from "./rules/no-invalid-properties.js";
 import noInvalidAtRules from "./rules/no-invalid-at-rules.js";
 import preferLogicalProperties from "./rules/prefer-logical-properties.js";
+import relativeFontUnits from "./rules/relative-font-units.js";
 import useLayers from "./rules/use-layers.js";
 import useBaseline from "./rules/use-baseline.js";
 
@@ -37,6 +38,7 @@ const plugin = {
 		"no-invalid-at-rules": noInvalidAtRules,
 		"no-invalid-properties": noInvalidProperties,
 		"prefer-logical-properties": preferLogicalProperties,
+		"relative-font-units": relativeFontUnits,
 		"use-layers": useLayers,
 		"use-baseline": useBaseline,
 	},

--- a/src/rules/relative-font-units.js
+++ b/src/rules/relative-font-units.js
@@ -1,0 +1,167 @@
+/**
+ * @fileoverview Enforce the use of relative units for font size.
+ * @author Tanuj Kanti
+ */
+
+//-----------------------------------------------------------------------------
+// Type Definitions
+//-----------------------------------------------------------------------------
+
+/**
+ * @import { CSSRuleDefinition } from "../types.js"
+ * @typedef {"allowedFontUnits"} RelativeFontUnitsMessageIds
+ * @typedef {[{allow?: string[]}]} RelativeFontUnitsOptions
+ * @typedef {CSSRuleDefinition<{ RuleOptions: RelativeFontUnitsOptions, MessageIds: RelativeFontUnitsMessageIds}>} RelativeFontUnitsRuleDefinition
+ */
+
+//-----------------------------------------------------------------------------
+// Helpers
+//-----------------------------------------------------------------------------
+
+const relativeFontUnits = [
+	"%",
+	"cap",
+	"ch",
+	"em",
+	"ex",
+	"ic",
+	"lh",
+	"rcap",
+	"rch",
+	"rem",
+	"rex",
+	"ric",
+	"rlh",
+];
+
+const fontSizeIdentifiers = new Set([
+	"xx-small",
+	"x-small",
+	"small",
+	"medium",
+	"large",
+	"x-large",
+	"xx-large",
+	"smaller",
+	"larger",
+]);
+
+//-----------------------------------------------------------------------------
+// Rule Definition
+//-----------------------------------------------------------------------------
+
+/** @type {RelativeFontUnitsRuleDefinition} */
+export default {
+	meta: {
+		type: "suggestion",
+
+		docs: {
+			description: "Enforce the use of relative font units",
+			recommended: false,
+			url: "https://github.com/eslint/css/blob/main/docs/rules/relative-font-units.md",
+		},
+
+		schema: [
+			{
+				type: "object",
+				properties: {
+					allow: {
+						type: "array",
+						items: {
+							enum: relativeFontUnits,
+							uniqueItems: true,
+						},
+					},
+				},
+			},
+		],
+
+		defaultOptions: [
+			{
+				allow: ["rem"],
+			},
+		],
+
+		messages: {
+			allowedFontUnits:
+				"Use only allowed relative units for 'font-size' - {{allowedFontUnits}}.",
+		},
+	},
+
+	create(context) {
+		const [{ allow: allowedFontUnits }] = context.options;
+
+		return {
+			Declaration(node) {
+				if (node.property === "font-size") {
+					const value = node.value.children[0];
+
+					if (
+						allowedFontUnits.includes("%") &&
+						value.type === "Percentage"
+					) {
+						return;
+					}
+
+					if (
+						!allowedFontUnits.includes(value?.unit) ||
+						value.type === "Identifier"
+					) {
+						context.report({
+							loc: value.loc,
+							messageId: "allowedFontUnits",
+							data: {
+								allowedFontUnits,
+							},
+						});
+					}
+				}
+
+				if (node.property === "font") {
+					const value = node.value;
+					const dimensionNode = value.children.find(
+						child => child.type === "Dimension",
+					);
+					const identifierNode = value.children.find(
+						child =>
+							child.type === "Identifier" &&
+							fontSizeIdentifiers.has(child.name),
+					);
+					const percentageNode = value.children.find(
+						child => child.type === "Percentage",
+					);
+					let location;
+					let shouldReport = false;
+
+					if (!allowedFontUnits.includes("%") && percentageNode) {
+						shouldReport = true;
+						location = percentageNode.loc;
+					}
+
+					if (identifierNode) {
+						shouldReport = true;
+						location = identifierNode.loc;
+					}
+
+					if (
+						dimensionNode &&
+						!allowedFontUnits.includes(dimensionNode.unit)
+					) {
+						shouldReport = true;
+						location = dimensionNode.loc;
+					}
+
+					if (shouldReport) {
+						context.report({
+							loc: location,
+							messageId: "allowedFontUnits",
+							data: {
+								allowedFontUnits,
+							},
+						});
+					}
+				}
+			},
+		};
+	},
+};

--- a/src/rules/relative-font-units.js
+++ b/src/rules/relative-font-units.js
@@ -94,71 +94,74 @@ export default {
 		return {
 			Declaration(node) {
 				if (node.property === "font-size") {
-					const value = node.value.children[0];
+					if (node.value.type === "Value") {
+						const value = node.value.children[0];
 
-					if (
-						allowedFontUnits.includes("%") &&
-						value.type === "Percentage"
-					) {
-						return;
-					}
-
-					if (
-						!allowedFontUnits.includes(value?.unit) ||
-						value.type === "Identifier"
-					) {
-						context.report({
-							loc: value.loc,
-							messageId: "allowedFontUnits",
-							data: {
-								allowedFontUnits,
-							},
-						});
+						if (
+							(value.type === "Dimension" &&
+								!allowedFontUnits.includes(value.unit)) ||
+							value.type === "Identifier" ||
+							(value.type === "Percentage" &&
+								!allowedFontUnits.includes("%"))
+						) {
+							context.report({
+								loc: value.loc,
+								messageId: "allowedFontUnits",
+								data: {
+									allowedFontUnits:
+										allowedFontUnits.join(", "),
+								},
+							});
+						}
 					}
 				}
 
 				if (node.property === "font") {
 					const value = node.value;
-					const dimensionNode = value.children.find(
-						child => child.type === "Dimension",
-					);
-					const identifierNode = value.children.find(
-						child =>
-							child.type === "Identifier" &&
-							fontSizeIdentifiers.has(child.name),
-					);
-					const percentageNode = value.children.find(
-						child => child.type === "Percentage",
-					);
-					let location;
-					let shouldReport = false;
 
-					if (!allowedFontUnits.includes("%") && percentageNode) {
-						shouldReport = true;
-						location = percentageNode.loc;
-					}
+					if (value.type === "Value") {
+						const dimensionNode = value.children.find(
+							child => child.type === "Dimension",
+						);
+						const identifierNode = value.children.find(
+							child =>
+								child.type === "Identifier" &&
+								fontSizeIdentifiers.has(child.name),
+						);
+						const percentageNode = value.children.find(
+							child => child.type === "Percentage",
+						);
+						let location;
+						let shouldReport = false;
 
-					if (identifierNode) {
-						shouldReport = true;
-						location = identifierNode.loc;
-					}
+						if (!allowedFontUnits.includes("%") && percentageNode) {
+							shouldReport = true;
+							location = percentageNode.loc;
+						}
 
-					if (
-						dimensionNode &&
-						!allowedFontUnits.includes(dimensionNode.unit)
-					) {
-						shouldReport = true;
-						location = dimensionNode.loc;
-					}
+						if (identifierNode) {
+							shouldReport = true;
+							location = identifierNode.loc;
+						}
 
-					if (shouldReport) {
-						context.report({
-							loc: location,
-							messageId: "allowedFontUnits",
-							data: {
-								allowedFontUnits,
-							},
-						});
+						if (
+							dimensionNode &&
+							!allowedFontUnits.includes(dimensionNode.unit)
+						) {
+							shouldReport = true;
+							location = dimensionNode.loc;
+						}
+
+						if (shouldReport) {
+							context.report({
+								loc: location,
+								messageId: "allowedFontUnits",
+								data: {
+									allowedFontUnits:
+										allowedFontUnits.join(", "),
+								},
+							});
+						}
 					}
 				}
 			},

--- a/src/rules/relative-font-units.js
+++ b/src/rules/relative-font-units.js
@@ -42,8 +42,15 @@ const fontSizeIdentifiers = new Set([
 	"large",
 	"x-large",
 	"xx-large",
+	"xxx-large",
 	"smaller",
 	"larger",
+	"math",
+	"inherit",
+	"initial",
+	"revert",
+	"revert-layer",
+	"unset",
 ]);
 
 //-----------------------------------------------------------------------------

--- a/src/rules/relative-font-units.js
+++ b/src/rules/relative-font-units.js
@@ -10,7 +10,7 @@
 /**
  * @import { CSSRuleDefinition } from "../types.js"
  * @typedef {"allowedFontUnits"} RelativeFontUnitsMessageIds
- * @typedef {[{allow?: string[]}]} RelativeFontUnitsOptions
+ * @typedef {[{allowUnits?: string[]}]} RelativeFontUnitsOptions
  * @typedef {CSSRuleDefinition<{ RuleOptions: RelativeFontUnitsOptions, MessageIds: RelativeFontUnitsMessageIds}>} RelativeFontUnitsRuleDefinition
  */
 
@@ -72,7 +72,7 @@ export default {
 			{
 				type: "object",
 				properties: {
-					allow: {
+					allowUnits: {
 						type: "array",
 						items: {
 							enum: relativeFontUnits,
@@ -85,7 +85,7 @@ export default {
 
 		defaultOptions: [
 			{
-				allow: ["rem"],
+				allowUnits: ["rem"],
 			},
 		],
 
@@ -96,7 +96,7 @@ export default {
 	},
 
 	create(context) {
-		const [{ allow: allowedFontUnits }] = context.options;
+		const [{ allowUnits: allowedFontUnits }] = context.options;
 
 		return {
 			Declaration(node) {

--- a/tests/rules/relative-font-units.test.js
+++ b/tests/rules/relative-font-units.test.js
@@ -194,6 +194,18 @@ ruleTester.run("relative-font-units", rule, {
 				},
 			],
 		},
+		{
+			code: dedent`
+                a {
+                    font: italic small-caps bold condensed 18rem/1.6px "Georgia", serif;
+                }
+            `,
+			options: [
+				{
+					allow: ["rem", "em"],
+				},
+			],
+		},
 	],
 	invalid: [
 		{
@@ -545,6 +557,22 @@ ruleTester.run("relative-font-units", rule, {
 			],
 		},
 		{
+			code: "a { font-size: xxx-large; }",
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: "a { font: xxx-large Arial, sans-serif; }",
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
 			code: "a { font-size: smaller; }",
 			errors: [
 				{
@@ -570,6 +598,102 @@ ruleTester.run("relative-font-units", rule, {
 		},
 		{
 			code: "a { font: larger Arial, sans-serif; }",
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: "a { font-size: math; }",
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: "a { font: math Arial, sans-serif; }",
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: "a { font-size: inherit; }",
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: "a { font: inherit Arial, sans-serif; }",
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: "a { font-size: initial; }",
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: "a { font: initial Arial, sans-serif; }",
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: "a { font-size: revert; }",
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: "a { font: revert Arial, sans-serif; }",
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: "a { font-size: revert-layer; }",
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: "a { font: revert-layer Arial, sans-serif; }",
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: "a { font-size: unset; }",
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: "a { font: unset Arial, sans-serif; }",
 			errors: [
 				{
 					messageId: "allowedFontUnits",
@@ -713,6 +837,55 @@ ruleTester.run("relative-font-units", rule, {
 					allow: ["lh", "rex", "%"],
 				},
 			],
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: dedent`
+                a {
+                    font: italic bold 1.2em/2 "Helvetica", sans-serif;
+                }
+            `,
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: dedent`
+                a {
+                    font: ultra-condensed small-caps 1.2em "Fira Sans", sans-serif;
+                }
+            `,
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: dedent`
+                a {
+                    font: italic small-caps 700 condensed 16px/1.5 "Helvetica Neue", sans-serif;
+                }
+            `,
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: dedent`
+                a {
+                    font: caption;
+                    font-size: 20px;
+                }
+            `,
 			errors: [
 				{
 					messageId: "allowedFontUnits",

--- a/tests/rules/relative-font-units.test.js
+++ b/tests/rules/relative-font-units.test.js
@@ -28,6 +28,8 @@ ruleTester.run("relative-font-units", rule, {
 		"a { font-size: 1rem; }",
 		"a { font: 2rem Arial, sans-serif; }",
 		"a { font: 1.2rem/2 Arial, sans-serif; }",
+		"a { font-size: var(--foo); }",
+		"a { font: Arial var(-foo); }",
 		{
 			code: "a { font-size: 1em; }",
 			options: [

--- a/tests/rules/relative-font-units.test.js
+++ b/tests/rules/relative-font-units.test.js
@@ -1,0 +1,721 @@
+/**
+ * @fileoverview Tests for relative-font-units rule.
+ * @author Tanuj Kanti
+ */
+
+//------------------------------------------------------------------------------
+// Imports
+//------------------------------------------------------------------------------
+
+import rule from "../../src/rules/relative-font-units.js";
+import css from "../../src/index.js";
+import { RuleTester } from "eslint";
+import dedent from "dedent";
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+	plugins: {
+		css,
+	},
+	language: "css/css",
+});
+
+ruleTester.run("relative-font-units", rule, {
+	valid: [
+		"a { font-size: 1rem; }",
+		"a { font: 2rem Arial, sans-serif; }",
+		"a { font: 1.2rem/2 Arial, sans-serif; }",
+		{
+			code: "a { font-size: 1em; }",
+			options: [
+				{
+					allow: ["em"],
+				},
+			],
+		},
+		{
+			code: "a { font-size: 20%; }",
+			options: [
+				{
+					allow: ["%"],
+				},
+			],
+		},
+		{
+			code: "a { font-size: 2cap; }",
+			options: [
+				{
+					allow: ["cap"],
+				},
+			],
+		},
+		{
+			code: "a { font-size: 20ch; }",
+			options: [
+				{
+					allow: ["ch"],
+				},
+			],
+		},
+		{
+			code: "a { font-size: 3ex; }",
+			options: [
+				{
+					allow: ["ex"],
+				},
+			],
+		},
+		{
+			code: "a { font-size: 2ic; }",
+			options: [
+				{
+					allow: ["ic"],
+				},
+			],
+		},
+		{
+			code: "a { font-size: 1lh; }",
+			options: [
+				{
+					allow: ["lh"],
+				},
+			],
+		},
+		{
+			code: "a { font-size: 2rcap; }",
+			options: [
+				{
+					allow: ["rcap"],
+				},
+			],
+		},
+		{
+			code: "a { font-size: 20rch; }",
+			options: [
+				{
+					allow: ["rch"],
+				},
+			],
+		},
+		{
+			code: "a { font-size: 2rex; }",
+			options: [
+				{
+					allow: ["rex"],
+				},
+			],
+		},
+		{
+			code: "a { font-size: 1.5ric; }",
+			options: [
+				{
+					allow: ["ric"],
+				},
+			],
+		},
+		{
+			code: "a { font-size: 1rlh; }",
+			options: [
+				{
+					allow: ["rlh"],
+				},
+			],
+		},
+		{
+			code: dedent`
+                a {
+                    font-size: 1rem;
+                }
+                b {
+                    font-size: 1em;
+                }
+            `,
+			options: [
+				{
+					allow: ["rem", "em"],
+				},
+			],
+		},
+		{
+			code: dedent`
+                a {
+                    font-size: 1em;
+                    height: 20px;
+                }
+            `,
+			options: [
+				{
+					allow: ["em"],
+				},
+			],
+		},
+		{
+			code: dedent`
+                a {
+                    font-size: 1em;
+                    height: 20px;
+                }
+                b {
+                    font-size: 1rem;
+                }
+            `,
+			options: [
+				{
+					allow: ["rem", "em"],
+				},
+			],
+		},
+		{
+			code: "a { font: 20% Arial, sans-serif; }",
+			options: [
+				{
+					allow: ["%"],
+				},
+			],
+		},
+		{
+			code: dedent`
+                a {
+                    font-size: 1rem;
+                    height: 20px;
+                }
+                b {
+                    font: 2em Arial, sans-serif;
+                }
+            `,
+			options: [
+				{
+					allow: ["rem", "em"],
+				},
+			],
+		},
+	],
+	invalid: [
+		{
+			code: "a { font-size: 1px; }",
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: "a { font-size: 1em; }",
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: "a { font-size: 1rem; }",
+			options: [
+				{
+					allow: ["em"],
+				},
+			],
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: "a { font-size: 20%; }",
+			options: [
+				{
+					allow: ["em"],
+				},
+			],
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: "a { font-size: 2em; }",
+			options: [
+				{
+					allow: ["%"],
+				},
+			],
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: "a { font-size: 20ch; }",
+			options: [
+				{
+					allow: ["cap"],
+				},
+			],
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: "a { font-size: 2cap; }",
+			options: [
+				{
+					allow: ["ch"],
+				},
+			],
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: "a { font-size: 10px; }",
+			options: [
+				{
+					allow: ["ex"],
+				},
+			],
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: "a { font-size: 2rem; }",
+			options: [
+				{
+					allow: ["ic"],
+				},
+			],
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: "a { font-size: 2ic; }",
+			options: [
+				{
+					allow: ["em"],
+				},
+			],
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: "a { font-size: 1rlh; }",
+			options: [
+				{
+					allow: ["lh"],
+				},
+			],
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: "a { font-size: 1lh; }",
+			options: [
+				{
+					allow: ["rcap"],
+				},
+			],
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: "a { font-size: 2in; }",
+			options: [
+				{
+					allow: ["rch"],
+				},
+			],
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: "a { font-size: 3ex; }",
+			options: [
+				{
+					allow: ["rex"],
+				},
+			],
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: "a { font-size: 2rem; }",
+			options: [
+				{
+					allow: ["ric"],
+				},
+			],
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: "a { font-size: 1lh; }",
+			options: [
+				{
+					allow: ["rlh"],
+				},
+			],
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: dedent`
+                a {
+                    font-size: 1rem;
+                }
+                b {
+                    font-size: 1em;
+                }
+            `,
+			options: [
+				{
+					allow: ["em"],
+				},
+			],
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: dedent`
+                a {
+                    font-size: 10px;
+                    height: 3em;
+                }
+            `,
+			options: [
+				{
+					allow: ["em"],
+				},
+			],
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: "a { font-size: xx-small; }",
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: "a { font: xx-small Arial, sans-serif; }",
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: "a { font-size: x-small; }",
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: "a { font: x-small Arial, sans-serif; }",
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: "a { font-size: small; }",
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: "a { font: small Arial, sans-serif; }",
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: "a { font-size: medium; }",
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: "a { font: medium Arial, sans-serif; }",
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: "a { font-size: large; }",
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: "a { font: large Arial, sans-serif; }",
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: "a { font-size: x-large; }",
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: "a { font: x-large Arial, sans-serif; }",
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: "a { font-size: xx-large; }",
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: "a { font: xx-large Arial, sans-serif; }",
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: "a { font-size: smaller; }",
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: "a { font: smaller Arial, sans-serif; }",
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: "a { font-size: larger; }",
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: "a { font: larger Arial, sans-serif; }",
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: dedent`
+                a {
+                    font: 2rem Arial, sans-serif;
+                }
+            `,
+			options: [
+				{
+					allow: ["em"],
+				},
+			],
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: dedent`
+                a {
+                    font: 20% Arial, sans-serif;
+                }
+            `,
+			options: [
+				{
+					allow: ["em"],
+				},
+			],
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: dedent`
+                a {
+                    font: 2em Arial, sans-serif;
+                }
+            `,
+			options: [
+				{
+					allow: ["%"],
+				},
+			],
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: dedent`
+                a {
+                    font: small Arial, sans-serif;
+                }
+            `,
+			options: [
+				{
+					allow: ["%"],
+				},
+			],
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: dedent`
+                a {
+                    font-size: 2rem;
+                }
+            `,
+			options: [
+				{
+					allow: ["%", "em"],
+				},
+			],
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: dedent`
+                a {
+                    font-size: 2rem;
+                }
+                b {
+                    font-size: 2em;
+                }
+            `,
+			options: [
+				{
+					allow: ["rem", "rex"],
+				},
+			],
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: dedent`
+                a {
+                    font-size: 2rem;
+                    height: 50%;
+                }
+                b {
+                    font-size: 2em;
+                }
+            `,
+			options: [
+				{
+					allow: ["rem", "rex", "%"],
+				},
+			],
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+		{
+			code: dedent`
+                a {
+                    font: italic bold 2rem "Helvetica", sans-serif;
+                }
+            `,
+			options: [
+				{
+					allow: ["lh", "rex", "%"],
+				},
+			],
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+				},
+			],
+		},
+	],
+});

--- a/tests/rules/relative-font-units.test.js
+++ b/tests/rules/relative-font-units.test.js
@@ -30,11 +30,12 @@ ruleTester.run("relative-font-units", rule, {
 		"a { font: 1.2rem/2 Arial, sans-serif; }",
 		"a { font-size: var(--foo); }",
 		"a { font: Arial var(-foo); }",
+		"a { font-size: calc(10px + 2px); }",
 		{
 			code: "a { font-size: 1em; }",
 			options: [
 				{
-					allow: ["em"],
+					allowUnits: ["em"],
 				},
 			],
 		},
@@ -42,7 +43,7 @@ ruleTester.run("relative-font-units", rule, {
 			code: "a { font-size: 20%; }",
 			options: [
 				{
-					allow: ["%"],
+					allowUnits: ["%"],
 				},
 			],
 		},
@@ -50,7 +51,7 @@ ruleTester.run("relative-font-units", rule, {
 			code: "a { font-size: 2cap; }",
 			options: [
 				{
-					allow: ["cap"],
+					allowUnits: ["cap"],
 				},
 			],
 		},
@@ -58,7 +59,7 @@ ruleTester.run("relative-font-units", rule, {
 			code: "a { font-size: 20ch; }",
 			options: [
 				{
-					allow: ["ch"],
+					allowUnits: ["ch"],
 				},
 			],
 		},
@@ -66,7 +67,7 @@ ruleTester.run("relative-font-units", rule, {
 			code: "a { font-size: 3ex; }",
 			options: [
 				{
-					allow: ["ex"],
+					allowUnits: ["ex"],
 				},
 			],
 		},
@@ -74,7 +75,7 @@ ruleTester.run("relative-font-units", rule, {
 			code: "a { font-size: 2ic; }",
 			options: [
 				{
-					allow: ["ic"],
+					allowUnits: ["ic"],
 				},
 			],
 		},
@@ -82,7 +83,7 @@ ruleTester.run("relative-font-units", rule, {
 			code: "a { font-size: 1lh; }",
 			options: [
 				{
-					allow: ["lh"],
+					allowUnits: ["lh"],
 				},
 			],
 		},
@@ -90,7 +91,7 @@ ruleTester.run("relative-font-units", rule, {
 			code: "a { font-size: 2rcap; }",
 			options: [
 				{
-					allow: ["rcap"],
+					allowUnits: ["rcap"],
 				},
 			],
 		},
@@ -98,7 +99,7 @@ ruleTester.run("relative-font-units", rule, {
 			code: "a { font-size: 20rch; }",
 			options: [
 				{
-					allow: ["rch"],
+					allowUnits: ["rch"],
 				},
 			],
 		},
@@ -106,7 +107,7 @@ ruleTester.run("relative-font-units", rule, {
 			code: "a { font-size: 2rex; }",
 			options: [
 				{
-					allow: ["rex"],
+					allowUnits: ["rex"],
 				},
 			],
 		},
@@ -114,7 +115,7 @@ ruleTester.run("relative-font-units", rule, {
 			code: "a { font-size: 1.5ric; }",
 			options: [
 				{
-					allow: ["ric"],
+					allowUnits: ["ric"],
 				},
 			],
 		},
@@ -122,7 +123,7 @@ ruleTester.run("relative-font-units", rule, {
 			code: "a { font-size: 1rlh; }",
 			options: [
 				{
-					allow: ["rlh"],
+					allowUnits: ["rlh"],
 				},
 			],
 		},
@@ -137,7 +138,7 @@ ruleTester.run("relative-font-units", rule, {
             `,
 			options: [
 				{
-					allow: ["rem", "em"],
+					allowUnits: ["rem", "em"],
 				},
 			],
 		},
@@ -150,7 +151,7 @@ ruleTester.run("relative-font-units", rule, {
             `,
 			options: [
 				{
-					allow: ["em"],
+					allowUnits: ["em"],
 				},
 			],
 		},
@@ -166,7 +167,7 @@ ruleTester.run("relative-font-units", rule, {
             `,
 			options: [
 				{
-					allow: ["rem", "em"],
+					allowUnits: ["rem", "em"],
 				},
 			],
 		},
@@ -174,7 +175,7 @@ ruleTester.run("relative-font-units", rule, {
 			code: "a { font: 20% Arial, sans-serif; }",
 			options: [
 				{
-					allow: ["%"],
+					allowUnits: ["%"],
 				},
 			],
 		},
@@ -190,7 +191,7 @@ ruleTester.run("relative-font-units", rule, {
             `,
 			options: [
 				{
-					allow: ["rem", "em"],
+					allowUnits: ["rem", "em"],
 				},
 			],
 		},
@@ -202,7 +203,7 @@ ruleTester.run("relative-font-units", rule, {
             `,
 			options: [
 				{
-					allow: ["rem", "em"],
+					allowUnits: ["rem", "em"],
 				},
 			],
 		},
@@ -228,7 +229,7 @@ ruleTester.run("relative-font-units", rule, {
 			code: "a { font-size: 1rem; }",
 			options: [
 				{
-					allow: ["em"],
+					allowUnits: ["em"],
 				},
 			],
 			errors: [
@@ -241,7 +242,7 @@ ruleTester.run("relative-font-units", rule, {
 			code: "a { font-size: 20%; }",
 			options: [
 				{
-					allow: ["em"],
+					allowUnits: ["em"],
 				},
 			],
 			errors: [
@@ -254,7 +255,7 @@ ruleTester.run("relative-font-units", rule, {
 			code: "a { font-size: 2em; }",
 			options: [
 				{
-					allow: ["%"],
+					allowUnits: ["%"],
 				},
 			],
 			errors: [
@@ -267,7 +268,7 @@ ruleTester.run("relative-font-units", rule, {
 			code: "a { font-size: 20ch; }",
 			options: [
 				{
-					allow: ["cap"],
+					allowUnits: ["cap"],
 				},
 			],
 			errors: [
@@ -280,7 +281,7 @@ ruleTester.run("relative-font-units", rule, {
 			code: "a { font-size: 2cap; }",
 			options: [
 				{
-					allow: ["ch"],
+					allowUnits: ["ch"],
 				},
 			],
 			errors: [
@@ -293,7 +294,7 @@ ruleTester.run("relative-font-units", rule, {
 			code: "a { font-size: 10px; }",
 			options: [
 				{
-					allow: ["ex"],
+					allowUnits: ["ex"],
 				},
 			],
 			errors: [
@@ -306,7 +307,7 @@ ruleTester.run("relative-font-units", rule, {
 			code: "a { font-size: 2rem; }",
 			options: [
 				{
-					allow: ["ic"],
+					allowUnits: ["ic"],
 				},
 			],
 			errors: [
@@ -319,7 +320,7 @@ ruleTester.run("relative-font-units", rule, {
 			code: "a { font-size: 2ic; }",
 			options: [
 				{
-					allow: ["em"],
+					allowUnits: ["em"],
 				},
 			],
 			errors: [
@@ -332,7 +333,7 @@ ruleTester.run("relative-font-units", rule, {
 			code: "a { font-size: 1rlh; }",
 			options: [
 				{
-					allow: ["lh"],
+					allowUnits: ["lh"],
 				},
 			],
 			errors: [
@@ -345,7 +346,7 @@ ruleTester.run("relative-font-units", rule, {
 			code: "a { font-size: 1lh; }",
 			options: [
 				{
-					allow: ["rcap"],
+					allowUnits: ["rcap"],
 				},
 			],
 			errors: [
@@ -358,7 +359,7 @@ ruleTester.run("relative-font-units", rule, {
 			code: "a { font-size: 2in; }",
 			options: [
 				{
-					allow: ["rch"],
+					allowUnits: ["rch"],
 				},
 			],
 			errors: [
@@ -371,7 +372,7 @@ ruleTester.run("relative-font-units", rule, {
 			code: "a { font-size: 3ex; }",
 			options: [
 				{
-					allow: ["rex"],
+					allowUnits: ["rex"],
 				},
 			],
 			errors: [
@@ -384,7 +385,7 @@ ruleTester.run("relative-font-units", rule, {
 			code: "a { font-size: 2rem; }",
 			options: [
 				{
-					allow: ["ric"],
+					allowUnits: ["ric"],
 				},
 			],
 			errors: [
@@ -397,7 +398,7 @@ ruleTester.run("relative-font-units", rule, {
 			code: "a { font-size: 1lh; }",
 			options: [
 				{
-					allow: ["rlh"],
+					allowUnits: ["rlh"],
 				},
 			],
 			errors: [
@@ -417,7 +418,7 @@ ruleTester.run("relative-font-units", rule, {
             `,
 			options: [
 				{
-					allow: ["em"],
+					allowUnits: ["em"],
 				},
 			],
 			errors: [
@@ -435,7 +436,7 @@ ruleTester.run("relative-font-units", rule, {
             `,
 			options: [
 				{
-					allow: ["em"],
+					allowUnits: ["em"],
 				},
 			],
 			errors: [
@@ -708,7 +709,7 @@ ruleTester.run("relative-font-units", rule, {
             `,
 			options: [
 				{
-					allow: ["em"],
+					allowUnits: ["em"],
 				},
 			],
 			errors: [
@@ -725,7 +726,7 @@ ruleTester.run("relative-font-units", rule, {
             `,
 			options: [
 				{
-					allow: ["em"],
+					allowUnits: ["em"],
 				},
 			],
 			errors: [
@@ -742,7 +743,7 @@ ruleTester.run("relative-font-units", rule, {
             `,
 			options: [
 				{
-					allow: ["%"],
+					allowUnits: ["%"],
 				},
 			],
 			errors: [
@@ -759,7 +760,7 @@ ruleTester.run("relative-font-units", rule, {
             `,
 			options: [
 				{
-					allow: ["%"],
+					allowUnits: ["%"],
 				},
 			],
 			errors: [
@@ -776,7 +777,7 @@ ruleTester.run("relative-font-units", rule, {
             `,
 			options: [
 				{
-					allow: ["%", "em"],
+					allowUnits: ["%", "em"],
 				},
 			],
 			errors: [
@@ -796,7 +797,7 @@ ruleTester.run("relative-font-units", rule, {
             `,
 			options: [
 				{
-					allow: ["rem", "rex"],
+					allowUnits: ["rem", "rex"],
 				},
 			],
 			errors: [
@@ -817,7 +818,7 @@ ruleTester.run("relative-font-units", rule, {
             `,
 			options: [
 				{
-					allow: ["rem", "rex", "%"],
+					allowUnits: ["rem", "rex", "%"],
 				},
 			],
 			errors: [
@@ -834,7 +835,7 @@ ruleTester.run("relative-font-units", rule, {
             `,
 			options: [
 				{
-					allow: ["lh", "rex", "%"],
+					allowUnits: ["lh", "rex", "%"],
 				},
 			],
 			errors: [


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?
Add a new rule called `relative-font-units` that will enforce the relative units for font size.

#### What changes did you make? (Give an overview)
Added the rule `relative-font-units` with an option called `allow` and related tests and docs and updated README.md file.

#### Related Issues

fixes #73

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
