### PR TITLE
feat: Allow function for customSyntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Setting `tolerant` to `true` is necessary if you are using custom syntax, such a
 
 The CSS lexer comes prebuilt with a set of known syntax for CSS that is used in rules like `no-invalid-properties` to validate CSS code. While this works for most cases, there may be cases when you want to define your own extensions to CSS, and this can be done using the `customSyntax` language option.
 
-The `customSyntax` option is an object that uses the [CSSTree format](https://github.com/csstree/csstree/blob/master/data/patch.json) for defining custom syntax, which allows you to specify at-rules, properties, and some types. For example, suppose you'd like to define a custom at-rule that looks like this:
+The `customSyntax` option is an object or function that uses the [CSSTree format](https://github.com/csstree/csstree/blob/master/data/patch.json) for defining custom syntax, which allows you to specify at-rules, properties, and some types. For example, suppose you'd like to define a custom at-rule that looks like this:
 
 ```css
 @my-at-rule "hello world!";

--- a/src/languages/css-language.js
+++ b/src/languages/css-language.js
@@ -22,7 +22,7 @@ import { visitorKeys } from "./css-visitor-keys.js";
 //-----------------------------------------------------------------------------
 
 /**
- * @import { CssNodePlain, Comment, Lexer, StyleSheetPlain, SyntaxConfig } from "@eslint/css-tree"
+ * @import { CssNodePlain, Comment, Lexer, StyleSheetPlain, SyntaxExtension } from "@eslint/css-tree"
  * @import { Language, OkParseResult, ParseResult, File, FileError } from "@eslint/core";
  */
 
@@ -31,7 +31,7 @@ import { visitorKeys } from "./css-visitor-keys.js";
 /**
  * @typedef {Object} CSSLanguageOptions
  * @property {boolean} [tolerant] Whether to be tolerant of recoverable parsing errors.
- * @property {SyntaxConfig} [customSyntax] Custom syntax to use for parsing.
+ * @property {SyntaxExtension} [customSyntax] Custom syntax to use for parsing.
  */
 
 //-----------------------------------------------------------------------------
@@ -115,11 +115,12 @@ export class CSSLanguage {
 
 		if ("customSyntax" in languageOptions) {
 			if (
-				typeof languageOptions.customSyntax !== "object" ||
+				(typeof languageOptions.customSyntax !== "function" &&
+					typeof languageOptions.customSyntax !== "object") ||
 				languageOptions.customSyntax === null
 			) {
 				throw new TypeError(
-					"Expected an object value for 'customSyntax' option.",
+					"Expected an object or function value for 'customSyntax' option.",
 				);
 			}
 		}


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Update `customSyntax` to accept a function. It turns out CSSTree allows either a function or an object, so expanding to match that.

#### What changes did you make? (Give an overview)

- Updated `CSSLanguage#validateLanguageOptions()` to accept functions
- Added tests for `CSSLanguage#validateLanguageOptions()`
- Updated the README


#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
