### PR TITLE
docs: add keyframe !important documentation

### DIFF
--- a/docs/rules/no-important.md
+++ b/docs/rules/no-important.md
@@ -13,13 +13,22 @@ The `!important` flag is a CSS declaration modifier that overrides normal cascad
 
 ## Rule Details
 
-This rule warns when it detects the `!important` flag in declarations.
+This rule warns when it detects the `!important` flag in declarations. This includes declarations within `@keyframes` rules, where `!important` is ignored by browsers and should be avoided.
 
 Examples of incorrect code:
 
 ```css
 .foo {
 	color: red !important;
+}
+
+@keyframes fade {
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1 !important; /* This is ignored by browsers */
+	}
 }
 ```
 
@@ -28,6 +37,15 @@ Examples of correct code:
 ```css
 .foo {
 	color: red;
+}
+
+@keyframes fade {
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1;
+	}
 }
 ```
 

--- a/tests/rules/no-important.test.js
+++ b/tests/rules/no-important.test.js
@@ -44,6 +44,9 @@ ruleTester.run("no-important", rule, {
 				},
 			},
 		},
+		"@keyframes important { from { margin: 1px; } }",
+		"@-webkit-keyframes important { from { margin: 1px; } }",
+		"@-WEBKIT-KEYFRAMES important { from { margin: 1px; } }",
 	],
 	invalid: [
 		{
@@ -257,6 +260,90 @@ ruleTester.run("no-important", rule, {
 					column: 3,
 					endLine: 5,
 					endColumn: 14,
+				},
+			],
+		},
+		{
+			code: "@keyframes important { from { margin: 1px !important; } }",
+			errors: [
+				{
+					messageId: "unexpectedImportant",
+					line: 1,
+					column: 43,
+					endLine: 1,
+					endColumn: 53,
+				},
+			],
+		},
+		{
+			code: "@-webkit-keyframes important { from { margin: 1px !important; } }",
+			errors: [
+				{
+					messageId: "unexpectedImportant",
+					line: 1,
+					column: 51,
+					endLine: 1,
+					endColumn: 61,
+				},
+			],
+		},
+		{
+			code: "@-WEBKIT-KEYFRAMES important { from { margin: 1px !important; } }",
+			errors: [
+				{
+					messageId: "unexpectedImportant",
+					line: 1,
+					column: 51,
+					endLine: 1,
+					endColumn: 61,
+				},
+			],
+		},
+		{
+			code: "@keyframes important { from { margin: 1px!important; } }",
+			errors: [
+				{
+					messageId: "unexpectedImportant",
+					line: 1,
+					column: 42,
+					endLine: 1,
+					endColumn: 52,
+				},
+			],
+		},
+		{
+			code: "@keyframes important { from { margin: 1px ! important; } }",
+			errors: [
+				{
+					messageId: "unexpectedImportant",
+					line: 1,
+					column: 43,
+					endLine: 1,
+					endColumn: 54,
+				},
+			],
+		},
+		{
+			code: "@kEyFrAmEs important { from { margin: 1px !important; } }",
+			errors: [
+				{
+					messageId: "unexpectedImportant",
+					line: 1,
+					column: 43,
+					endLine: 1,
+					endColumn: 53,
+				},
+			],
+		},
+		{
+			code: "@KEYFRAMES important { from { margin: 1px !important; } }",
+			errors: [
+				{
+					messageId: "unexpectedImportant",
+					line: 1,
+					column: 43,
+					endLine: 1,
+					endColumn: 53,
 				},
 			],
 		},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This PR addresses issue #146 by documenting that !important declarations within `@keyframes` rules are ignored by browsers. While this case is already caught by the existing no-important rule, the documentation update makes this behavior more explicit and helps developers understand why using !important in keyframes is problematic.

#### What changes did you make? (Give an overview)

- Updated the no-important rule documentation to explicitly mention that !important declarations within `@keyframes` rules are ignored by browsers

- Added test cases for keyframe !important validation

#### Related Issues

Fixes #146

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
