### PR TITLE
fix: tailwind-syntax should allow plugin atrule

### DIFF
--- a/src/syntax/tailwind-syntax.js
+++ b/src/syntax/tailwind-syntax.js
@@ -13,6 +13,9 @@ export default {
 		config: {
 			prelude: "<string>",
 		},
+		plugin: {
+			prelude: "<string>",
+		},
 	},
 
 	/*


### PR DESCRIPTION
For example:

```css
@import "tailwindcss";
@plugin '@tailwindcss/typography';

```