### PR TITLE
feat: add no-invalid-named-grid-areas rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,17 +65,18 @@ export default defineConfig([
 
 <!-- Rule Table Start -->
 
-| **Rule Name**                                                            | **Description**                        | **Recommended** |
-| :----------------------------------------------------------------------- | :------------------------------------- | :-------------: |
-| [`no-duplicate-imports`](./docs/rules/no-duplicate-imports.md)           | Disallow duplicate @import rules       |       yes       |
-| [`no-empty-blocks`](./docs/rules/no-empty-blocks.md)                     | Disallow empty blocks                  |       yes       |
-| [`no-important`](./docs/rules/no-important.md)                           | Disallow !important flags              |       yes       |
-| [`no-invalid-at-rules`](./docs/rules/no-invalid-at-rules.md)             | Disallow invalid at-rules              |       yes       |
-| [`no-invalid-properties`](./docs/rules/no-invalid-properties.md)         | Disallow invalid properties            |       yes       |
-| [`prefer-logical-properties`](./docs/rules/prefer-logical-properties.md) | Enforce the use of logical properties  |       no        |
-| [`relative-font-units`](./docs/rules/relative-font-units.md)             | Enforce the use of relative font units |       no        |
-| [`use-baseline`](./docs/rules/use-baseline.md)                           | Enforce the use of baseline features   |       yes       |
-| [`use-layers`](./docs/rules/use-layers.md)                               | Require use of layers                  |       no        |
+| **Rule Name**                                                                | **Description**                        | **Recommended** |
+| :--------------------------------------------------------------------------- | :------------------------------------- | :-------------: |
+| [`no-duplicate-imports`](./docs/rules/no-duplicate-imports.md)               | Disallow duplicate @import rules       |       yes       |
+| [`no-empty-blocks`](./docs/rules/no-empty-blocks.md)                         | Disallow empty blocks                  |       yes       |
+| [`no-important`](./docs/rules/no-important.md)                               | Disallow !important flags              |       yes       |
+| [`no-invalid-at-rules`](./docs/rules/no-invalid-at-rules.md)                 | Disallow invalid at-rules              |       yes       |
+| [`no-invalid-named-grid-areas`](./docs/rules/no-invalid-named-grid-areas.md) | Disallow invalid named grid areas      |       yes       |
+| [`no-invalid-properties`](./docs/rules/no-invalid-properties.md)             | Disallow invalid properties            |       yes       |
+| [`prefer-logical-properties`](./docs/rules/prefer-logical-properties.md)     | Enforce the use of logical properties  |       no        |
+| [`relative-font-units`](./docs/rules/relative-font-units.md)                 | Enforce the use of relative font units |       no        |
+| [`use-baseline`](./docs/rules/use-baseline.md)                               | Enforce the use of baseline features   |       yes       |
+| [`use-layers`](./docs/rules/use-layers.md)                                   | Require use of layers                  |       no        |
 
 <!-- Rule Table End -->
 

--- a/docs/rules/no-invalid-named-grid-areas.md
+++ b/docs/rules/no-invalid-named-grid-areas.md
@@ -1,0 +1,91 @@
+# no-invalid-named-grid-areas
+
+Disallow invalid named grid areas.
+
+## Background
+
+CSS Grid allows you to define named grid areas using the `grid-template-areas` property. Each string in the value creates a row, and each cell token in the string creates a column. Multiple cell tokens with the same name within and between rows create a single named grid area that spans the corresponding grid cells.
+
+A named grid area is considered invalid if:
+
+1. The strings in the value have different numbers of cell tokens
+2. No cell tokens are present
+3. Cell tokens with the same name do not form a rectangle
+
+## Rule Details
+
+This rule prevents invalid named grid areas in CSS grid templates.
+
+Examples of **incorrect** code:
+
+```css
+/* eslint css/no-invalid-named-grid-areas: "error" */
+
+.grid {
+	grid-template-areas: "";
+}
+```
+
+```css
+/* eslint css/no-invalid-named-grid-areas: "error" */
+
+.grid {
+	grid-template-areas:
+		"header header header"
+		"nav main main main";
+}
+```
+
+```css
+/* eslint css/no-invalid-named-grid-areas: "error" */
+
+.grid {
+	grid-template-areas:
+		"header header header"
+		"nav main main"
+		"nav . main";
+}
+```
+
+Examples of **correct** code:
+
+```css
+/* eslint css/no-invalid-named-grid-areas: "error" */
+
+.grid {
+	grid-template-areas:
+		"header"
+		"nav"
+		"main";
+}
+```
+
+```css
+/* eslint css/no-invalid-named-grid-areas: "error" */
+
+.grid {
+	grid-template-areas:
+		"header header header"
+		"nav main main"
+		"nav main main";
+}
+```
+
+```css
+/* eslint css/no-invalid-named-grid-areas: "error" */
+
+.grid {
+	grid-template-areas:
+		"header header header"
+		"nav . main"
+		"nav . main";
+}
+```
+
+## When Not to Use It
+
+If you aren't concerned with invalid grid area definitions, then you can safely disable this rule.
+
+## Prior Art
+
+- [`named-grid-areas-no-invalid`](https://stylelint.io/user-guide/rules/named-grid-areas-no-invalid)

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ import noDuplicateImports from "./rules/no-duplicate-imports.js";
 import noImportant from "./rules/no-important.js";
 import noInvalidProperties from "./rules/no-invalid-properties.js";
 import noInvalidAtRules from "./rules/no-invalid-at-rules.js";
+import noInvalidNamedGridAreas from "./rules/no-invalid-named-grid-areas.js";
 import preferLogicalProperties from "./rules/prefer-logical-properties.js";
 import relativeFontUnits from "./rules/relative-font-units.js";
 import useLayers from "./rules/use-layers.js";
@@ -36,6 +37,7 @@ const plugin = {
 		"no-duplicate-imports": noDuplicateImports,
 		"no-important": noImportant,
 		"no-invalid-at-rules": noInvalidAtRules,
+		"no-invalid-named-grid-areas": noInvalidNamedGridAreas,
 		"no-invalid-properties": noInvalidProperties,
 		"prefer-logical-properties": preferLogicalProperties,
 		"relative-font-units": relativeFontUnits,
@@ -50,6 +52,7 @@ const plugin = {
 				"css/no-duplicate-imports": "error",
 				"css/no-important": "error",
 				"css/no-invalid-at-rules": "error",
+				"css/no-invalid-named-grid-areas": "error",
 				"css/no-invalid-properties": "error",
 				"css/use-baseline": "warn",
 			}),

--- a/src/rules/no-invalid-named-grid-areas.js
+++ b/src/rules/no-invalid-named-grid-areas.js
@@ -29,6 +29,7 @@ const nullCellToken = /^\.+$/u;
  */
 function findNonRectangularAreas(grid) {
 	const errors = [];
+	const reported = new Set();
 	const names = [...new Set(grid.flat())].filter(
 		name => !nullCellToken.test(name),
 	);
@@ -59,8 +60,11 @@ function findNonRectangularAreas(grid) {
 					row1.length !== row2.length ||
 					!row1.every((val, idx) => val === row2[idx])
 				) {
-					const firstRow = grid.findIndex(r => r.includes(name));
-					errors.push({ name, row: firstRow });
+					const key = `${name}|${j}`;
+					if (!reported.has(key)) {
+						errors.push({ name, row: j });
+						reported.add(key);
+					}
 				}
 			}
 		}

--- a/src/rules/no-invalid-named-grid-areas.js
+++ b/src/rules/no-invalid-named-grid-areas.js
@@ -1,0 +1,174 @@
+/**
+ * @fileoverview Rule to prevent invalid named grid areas in CSS grid templates.
+ * @author xbinaryx
+ */
+
+//-----------------------------------------------------------------------------
+// Type Definitions
+//-----------------------------------------------------------------------------
+
+/**
+ * @import { CSSRuleDefinition } from "../types.js"
+ * @typedef {"emptyGridArea" | "unevenGridArea" | "nonRectangularGridArea"} NoInvalidNamedGridAreasMessageIds
+ * @typedef {CSSRuleDefinition<{ RuleOptions: [], MessageIds: NoInvalidNamedGridAreasMessageIds }>} NoInvalidNamedGridAreasRuleDefinition
+ */
+
+//-----------------------------------------------------------------------------
+// Helpers
+//-----------------------------------------------------------------------------
+
+/**
+ * Regular expression to match null cell tokens (sequences of one or more dots)
+ */
+const nullCellToken = /^\.+$/u;
+
+/**
+ * Finds non-rectangular grid areas in a 2D grid
+ * @param {string[][]} grid 2D array representing the grid areas
+ * @returns {Array<{name: string, row: number}>} Array of errors found
+ */
+function findNonRectangularAreas(grid) {
+	const errors = [];
+	const names = [...new Set(grid.flat())].filter(
+		name => !nullCellToken.test(name),
+	);
+
+	for (const name of names) {
+		const indicesByRow = grid.map(row => {
+			const indices = [];
+			let idx = row.indexOf(name);
+
+			while (idx !== -1) {
+				indices.push(idx);
+				idx = row.indexOf(name, idx + 1);
+			}
+
+			return indices;
+		});
+
+		for (let i = 0; i < indicesByRow.length; i++) {
+			for (let j = i + 1; j < indicesByRow.length; j++) {
+				const row1 = indicesByRow[i];
+				const row2 = indicesByRow[j];
+
+				if (row1.length === 0 || row2.length === 0) {
+					continue;
+				}
+
+				if (
+					row1.length !== row2.length ||
+					!row1.every((val, idx) => val === row2[idx])
+				) {
+					const firstRow = grid.findIndex(r => r.includes(name));
+					errors.push({ name, row: firstRow });
+				}
+			}
+		}
+	}
+
+	return errors;
+}
+
+const validProps = new Set(["grid-template-areas", "grid-template", "grid"]);
+
+//-----------------------------------------------------------------------------
+// Rule Definition
+//-----------------------------------------------------------------------------
+
+/** @type {NoInvalidNamedGridAreasRuleDefinition} */
+export default {
+	meta: {
+		type: "problem",
+
+		docs: {
+			description: "Disallow invalid named grid areas",
+			recommended: true,
+			url: "https://github.com/eslint/css/blob/main/docs/rules/no-invalid-named-grid-areas.md",
+		},
+
+		messages: {
+			emptyGridArea: "Grid area must contain at least one cell token.",
+			unevenGridArea:
+				"Grid area strings must have the same number of cell tokens.",
+			nonRectangularGridArea:
+				"Cell tokens with name '{{name}}' must form a rectangle.",
+		},
+	},
+
+	create(context) {
+		return {
+			Declaration(node) {
+				const propName = node.property.toLowerCase();
+
+				if (
+					validProps.has(propName) &&
+					node.value.type === "Value" &&
+					node.value.children.length > 0
+				) {
+					const stringNodes = node.value.children.filter(
+						child => child.type === "String",
+					);
+
+					if (stringNodes.length === 0) {
+						return;
+					}
+
+					const grid = [];
+					const emptyNodes = [];
+					const unevenNodes = [];
+					let firstRowLen = null;
+
+					for (const stringNode of stringNodes) {
+						const trimmedValue = stringNode.value.trim();
+
+						if (trimmedValue === "") {
+							emptyNodes.push(stringNode);
+							continue;
+						}
+
+						const row = trimmedValue.split(" ").filter(Boolean);
+						grid.push(row);
+
+						if (firstRowLen === null) {
+							firstRowLen = row.length;
+						} else if (row.length !== firstRowLen) {
+							unevenNodes.push(stringNode);
+						}
+					}
+
+					if (emptyNodes.length > 0) {
+						emptyNodes.forEach(emptyNode =>
+							context.report({
+								node: emptyNode,
+								messageId: "emptyGridArea",
+							}),
+						);
+						return;
+					}
+
+					if (unevenNodes.length > 0) {
+						unevenNodes.forEach(unevenNode =>
+							context.report({
+								node: unevenNode,
+								messageId: "unevenGridArea",
+							}),
+						);
+						return;
+					}
+
+					const nonRectErrors = findNonRectangularAreas(grid);
+					nonRectErrors.forEach(({ name, row }) => {
+						const stringNode = stringNodes[row];
+						context.report({
+							node: stringNode,
+							messageId: "nonRectangularGridArea",
+							data: {
+								name,
+							},
+						});
+					});
+				}
+			},
+		};
+	},
+};

--- a/tests/rules/no-invalid-named-grid-areas.test.js
+++ b/tests/rules/no-invalid-named-grid-areas.test.js
@@ -90,6 +90,32 @@ ruleTester.run("no-invalid-named-grid-areas", rule, {
 			],
 		},
 		{
+			code: 'a { grid-template-areas: "a a" "a ."; }',
+			errors: [
+				{
+					messageId: "nonRectangularGridArea",
+					data: { name: "a" },
+					line: 1,
+					column: 32,
+					endLine: 1,
+					endColumn: 37,
+				},
+			],
+		},
+		{
+			code: 'a { grid-template-areas: ". y y" "y y ."; }',
+			errors: [
+				{
+					messageId: "nonRectangularGridArea",
+					data: { name: "y" },
+					line: 1,
+					column: 34,
+					endLine: 1,
+					endColumn: 41,
+				},
+			],
+		},
+		{
 			code: 'a { grid-template-areas: "a c a" "c b a"; }',
 			errors: [
 				{

--- a/tests/rules/no-invalid-named-grid-areas.test.js
+++ b/tests/rules/no-invalid-named-grid-areas.test.js
@@ -90,28 +90,36 @@ ruleTester.run("no-invalid-named-grid-areas", rule, {
 			],
 		},
 		{
-			code: 'a { grid-template-areas: "a a" "a ."; }',
+			code: dedent`
+			a { grid-template-areas:
+			        "a a"
+			        "a ."; 
+			}`,
 			errors: [
 				{
 					messageId: "nonRectangularGridArea",
 					data: { name: "a" },
-					line: 1,
-					column: 32,
-					endLine: 1,
-					endColumn: 37,
+					line: 3,
+					column: 9,
+					endLine: 3,
+					endColumn: 14,
 				},
 			],
 		},
 		{
-			code: 'a { grid-template-areas: ". y y" "y y ."; }',
+			code: dedent`
+			a { grid-template-areas:
+			        ". y y"
+			        "y y .";
+			}`,
 			errors: [
 				{
 					messageId: "nonRectangularGridArea",
 					data: { name: "y" },
-					line: 1,
-					column: 34,
-					endLine: 1,
-					endColumn: 41,
+					line: 3,
+					column: 9,
+					endLine: 3,
+					endColumn: 16,
 				},
 			],
 		},

--- a/tests/rules/no-invalid-named-grid-areas.test.js
+++ b/tests/rules/no-invalid-named-grid-areas.test.js
@@ -27,11 +27,17 @@ ruleTester.run("no-invalid-named-grid-areas", rule, {
 	valid: [
 		".grid { grid-template-areas: 1fr / auto 1fr auto; }",
 		'.grid { grid-template-areas: "a a a" "b b b"; }',
+		'.grid { grid-template-areas: " a a a " "b b b"; }',
 		'.grid { GRID-TEMPLATE-AREAS: "a a a" "b b b"; }',
 		dedent`
         .grid { grid-template-areas: "head head"
                                      "nav  main"
 						             "nav  foot"; 
+        }`,
+		dedent`
+        .grid { grid-template-areas: "head      head"
+                                     "nav       main"
+						             "nav       foot"; 
         }`,
 		dedent`
         .grid { grid-template-areas: 
@@ -77,9 +83,9 @@ ruleTester.run("no-invalid-named-grid-areas", rule, {
 					messageId: "nonRectangularGridArea",
 					data: { name: "a" },
 					line: 1,
-					column: 26,
+					column: 34,
 					endLine: 1,
-					endColumn: 33,
+					endColumn: 41,
 				},
 			],
 		},
@@ -90,17 +96,17 @@ ruleTester.run("no-invalid-named-grid-areas", rule, {
 					messageId: "nonRectangularGridArea",
 					data: { name: "a" },
 					line: 1,
-					column: 26,
+					column: 34,
 					endLine: 1,
-					endColumn: 33,
+					endColumn: 41,
 				},
 				{
 					messageId: "nonRectangularGridArea",
 					data: { name: "c" },
 					line: 1,
-					column: 26,
+					column: 34,
 					endLine: 1,
-					endColumn: 33,
+					endColumn: 41,
 				},
 			],
 		},
@@ -115,10 +121,10 @@ ruleTester.run("no-invalid-named-grid-areas", rule, {
 				{
 					messageId: "nonRectangularGridArea",
 					data: { name: "header" },
-					line: 2,
-					column: 28,
-					endLine: 2,
-					endColumn: 57,
+					line: 4,
+					column: 11,
+					endLine: 4,
+					endColumn: 40,
 				},
 			],
 		},

--- a/tests/rules/no-invalid-named-grid-areas.test.js
+++ b/tests/rules/no-invalid-named-grid-areas.test.js
@@ -1,0 +1,256 @@
+/**
+ * @fileoverview Tests for no-invalid-named-grid-areas rule.
+ * @author xbinaryx
+ */
+
+//------------------------------------------------------------------------------
+// Imports
+//------------------------------------------------------------------------------
+
+import rule from "../../src/rules/no-invalid-named-grid-areas.js";
+import css from "../../src/index.js";
+import { RuleTester } from "eslint";
+import dedent from "dedent";
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+	plugins: {
+		css,
+	},
+	language: "css/css",
+});
+
+ruleTester.run("no-invalid-named-grid-areas", rule, {
+	valid: [
+		".grid { grid-template-areas: 1fr / auto 1fr auto; }",
+		'.grid { grid-template-areas: "a a a" "b b b"; }',
+		'.grid { GRID-TEMPLATE-AREAS: "a a a" "b b b"; }',
+		dedent`
+        .grid { grid-template-areas: "head head"
+                                     "nav  main"
+						             "nav  foot"; 
+        }`,
+		dedent`
+        .grid { grid-template-areas: 
+                /* "" */ "head head"
+                "nav  main" /* "a b c" */
+				"nav  foot" /* "" */;
+        }`,
+		".grid { grid-template-areas: none; }",
+		".grid { grid-template-areas:   none; }",
+		".grid { grid-template-areas: NONE; }",
+		".grid { grid-template-areas: /*comment*/ none /* comment */; }",
+		".grid { grid-template-areas: /*comment*/ NONE /* comment */; }",
+		'.grid { grid-template-areas: /* comment "" " */ none; }',
+		dedent`
+        .grid {
+            grid-template-areas: /* "comment" */ none /* "comment " */;
+        }`,
+		dedent`
+        .grid {
+			grid-template:
+				"a a a" 40px
+				"b c c" 40px
+				"b c c" 40px / 1fr 1fr 1fr;
+		}`,
+	],
+	invalid: [
+		{
+			code: 'a { grid-template-areas: "a a a" "b b"; }',
+			errors: [
+				{
+					messageId: "unevenGridArea",
+					line: 1,
+					column: 34,
+					endLine: 1,
+					endColumn: 39,
+				},
+			],
+		},
+		{
+			code: 'a { grid-template-areas: "a a a" "b b a"; }',
+			errors: [
+				{
+					messageId: "nonRectangularGridArea",
+					data: { name: "a" },
+					line: 1,
+					column: 26,
+					endLine: 1,
+					endColumn: 33,
+				},
+			],
+		},
+		{
+			code: 'a { grid-template-areas: "a c a" "c b a"; }',
+			errors: [
+				{
+					messageId: "nonRectangularGridArea",
+					data: { name: "a" },
+					line: 1,
+					column: 26,
+					endLine: 1,
+					endColumn: 33,
+				},
+				{
+					messageId: "nonRectangularGridArea",
+					data: { name: "c" },
+					line: 1,
+					column: 26,
+					endLine: 1,
+					endColumn: 33,
+				},
+			],
+		},
+		{
+			code: dedent`
+            a {
+                  grid-template-areas: "header header header header"
+                      "main main . sidebar"
+                      "footer footer footer header";
+            }`,
+			errors: [
+				{
+					messageId: "nonRectangularGridArea",
+					data: { name: "header" },
+					line: 2,
+					column: 28,
+					endLine: 2,
+					endColumn: 57,
+				},
+			],
+		},
+		{
+			code: 'a { grid-template-areas: ""; }',
+			errors: [
+				{
+					messageId: "emptyGridArea",
+					line: 1,
+					column: 26,
+					endLine: 1,
+					endColumn: 28,
+				},
+			],
+		},
+		{
+			code: 'a { grid-template-areas: /* "comment" */ ""; }',
+			errors: [
+				{
+					messageId: "emptyGridArea",
+					line: 1,
+					column: 42,
+					endLine: 1,
+					endColumn: 44,
+				},
+			],
+		},
+		{
+			code: dedent`
+            a { grid-template-areas:
+                "";
+            }`,
+			errors: [
+				{
+					messageId: "emptyGridArea",
+					line: 2,
+					column: 5,
+					endLine: 2,
+					endColumn: 7,
+				},
+			],
+		},
+		{
+			code: 'a { grid-template-areas: "" "" ""; }',
+			errors: [
+				{
+					messageId: "emptyGridArea",
+					line: 1,
+					column: 26,
+					endLine: 1,
+					endColumn: 28,
+				},
+				{
+					messageId: "emptyGridArea",
+					line: 1,
+					column: 29,
+					endLine: 1,
+					endColumn: 31,
+				},
+				{
+					messageId: "emptyGridArea",
+					line: 1,
+					column: 32,
+					endLine: 1,
+					endColumn: 34,
+				},
+			],
+		},
+		{
+			code: dedent`
+            a {
+                grid-template-areas: /* none */
+                     "" /* none */;
+            }`,
+			errors: [
+				{
+					messageId: "emptyGridArea",
+					line: 3,
+					column: 10,
+					endLine: 3,
+					endColumn: 12,
+				},
+			],
+		},
+		{
+			code: 'a { GRID-TEMPLATE-AREAS: ""; }',
+			errors: [
+				{
+					messageId: "emptyGridArea",
+					line: 1,
+					column: 26,
+					endLine: 1,
+					endColumn: 28,
+				},
+			],
+		},
+		{
+			code: dedent`
+            a {
+                grid-template:
+                    "a a" 40px
+                    "b c c" 40px
+                    "b c c" 40px / 1fr 1fr 1fr;
+            }`,
+			errors: [
+				{
+					messageId: "unevenGridArea",
+					line: 4,
+					column: 9,
+					endLine: 4,
+					endColumn: 16,
+				},
+				{
+					messageId: "unevenGridArea",
+					line: 5,
+					column: 9,
+					endLine: 5,
+					endColumn: 16,
+				},
+			],
+		},
+		{
+			code: 'a { grid: "" 200px "b" min-content; }',
+			errors: [
+				{
+					messageId: "emptyGridArea",
+					line: 1,
+					column: 11,
+					endLine: 1,
+					endColumn: 13,
+				},
+			],
+		},
+	],
+});


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This PR adds a new rule `no-invalid-named-grid-areas` to enforce valid named grid area definitions in CSS Grid templates. The rule helps prevent common mistakes when using grid-template-areas and related properties by checking that named grid areas are properly defined according to the CSS Grid specification.

#### What changes did you make? (Give an overview)

Added the  `no-invalid-named-grid-areas` rule, along with documentation and tests.

#### Related Issues

Fixes #158

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
