### PR TITLE
fix: css syntax for `no-invalid-properties` tests

### DIFF
--- a/tests/rules/no-invalid-properties.test.js
+++ b/tests/rules/no-invalid-properties.test.js
@@ -35,7 +35,7 @@ ruleTester.run("no-invalid-properties", rule, {
 		"a { --my-color: red; color: var(--my-color) }",
 		":root { --my-color: red; }\na { color: var(--my-color) }",
 		":root { --my-color: red; }\na { color: var(   --my-color   ) }",
-		":root { --my-color: red;\n.foo { color: var(--my-color) }\n}",
+		":root { --my-color: red; }\n.foo { color: var(--my-color) }",
 		{
 			code: "a { my-custom-color: red; }",
 			languageOptions: {
@@ -265,7 +265,7 @@ ruleTester.run("no-invalid-properties", rule, {
 			],
 		},
 		{
-			code: "a { .foo { color: var(--undefined-var); } }",
+			code: "a.foo { color: var(--undefined-var); }",
 			errors: [
 				{
 					messageId: "unknownVar",
@@ -273,9 +273,9 @@ ruleTester.run("no-invalid-properties", rule, {
 						var: "--undefined-var",
 					},
 					line: 1,
-					column: 23,
+					column: 20,
 					endLine: 1,
-					endColumn: 38,
+					endColumn: 35,
 				},
 			],
 		},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?
To fix css syntax for `no-invalid-properties` tests

#### What changes did you make? (Give an overview)
Fixed tests in `no-invalid-properties`  that contain nested block.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
