### PR TITLE
fix: Enforce unique items in the options of `prefer-logical-properties`

### DIFF
--- a/src/rules/prefer-logical-properties.js
+++ b/src/rules/prefer-logical-properties.js
@@ -154,12 +154,14 @@ export default {
 						items: {
 							type: "string",
 						},
+						uniqueItems: true,
 					},
 					allowUnits: {
 						type: "array",
 						items: {
 							type: "string",
 						},
+						uniqueItems: true,
 					},
 				},
 				additionalProperties: false,


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Hello,

In this PR, I’ve added `uniqueItems: true` to the JSON schema of `prefer-logical-properties`.

Currently, users can pass duplicate properties like this:

![image](https://github.com/user-attachments/assets/f039b67e-979e-42b5-9ebd-13bb03e219f4)

However, considering the purpose of the option, it makes more sense to allow only unique items.

#### What changes did you make? (Give an overview)

I’ve added `uniqueItems: true` to the JSON schema of `prefer-logical-properties`.

#### Related Issues

Nothing.

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

Nothing.

<!-- markdownlint-disable-file MD004 -->
