### PR TITLE
chore: fix wrong JSDoc tag

### DIFF
--- a/src/languages/css-language.js
+++ b/src/languages/css-language.js
@@ -1,5 +1,5 @@
 /**
- * @filedescription The CSSLanguage class.
+ * @fileoverview The CSSLanguage class.
  * @author Nicholas C. Zakas
  */
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

**Edited**:

In this PR, I've fixed wrong JSDoc directive.

#### What changes did you make? (Give an overview)

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
