### PR TITLE
chore: fix CI error related to prettier `fmt`

### DIFF
--- a/docs/rules/relative-font-units.md
+++ b/docs/rules/relative-font-units.md
@@ -26,7 +26,6 @@ This rule enforces the use of relative units for font size.
 This rule accepts an option which is an object with the following property:
 
 - `allowUnits` (default: `["rem"]`) - Specify an array of relative units that are allowed to be used. You can use the following units:
-
     - **%**: Represents the "percentage" of the parent element’s font size, allowing the text to scale relative to its container.
     - **cap**: Represents the "cap height" (nominal height of capital letters) of the element's font.
     - **ch**: Represents the width or advance measure of the "0" glyph in the element's font.

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "mdast-util-from-markdown": "^2.0.2",
     "mdn-data": "^2.21.0",
     "mocha": "^10.4.0",
-    "prettier": "^3.4.1",
+    "prettier": "^3.6.0",
     "rollup": "^4.16.2",
     "rollup-plugin-copy": "^3.5.0",
     "rollup-plugin-delete": "^3.0.1",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Hello,

This PR fixes the CI error related to Prettier's `fmt` command.

Currently, the CI fails on main branch.

![image](https://github.com/user-attachments/assets/997058ba-a069-4a4e-a1a6-00c50b13133a)

The source of this error was an inconsistency between the old Prettier version and the newly released Prettier [`v3.6.0`](https://github.com/prettier/prettier/releases/tag/3.6.0).

This PR fixes the following references:

- https://github.com/eslint/css/actions/runs/15828665725/job/44741534972
- https://github.com/eslint/css/pull/178#issuecomment-3000887950

#### What changes did you make? (Give an overview)

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
