### PR TITLE
chore: workaround for ci error caused by `minimatch`

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
   },
   "devDependencies": {
     "@eslint/json": "^0.5.0",
-    "@types/minimatch": "^5.1.2",
     "c8": "^9.1.0",
     "compute-baseline": "^0.3.1",
     "dedent": "^1.5.3",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "target": "ES2022",
     "lib": ["ES2022"],
     "moduleResolution": "NodeNext",
-    "module": "NodeNext"
+    "module": "NodeNext",
+    "types": []
   }
 }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Hello,

This PR is a workaround for the CI error caused by `minimatch`.

Installing `@types/minimatch` resolves the CI error.

I think we can revisit a complete solution once the immediate errors are addressed.

#### What changes did you make? (Give an overview)

#### Related Issues

Refs: https://github.com/eslint/json/pull/117, https://github.com/eslint/css/issues/188

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
