### PR TITLE
chore: enable skipLibCheck

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "allowJs": true,
     "checkJs": true,
     "outDir": "dist/esm",
+    "skipLibCheck": true,
     "target": "ES2022",
     "lib": ["ES2022"],
     "moduleResolution": "NodeNext",


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request?

Prevents type errors from being reported when run inside a directory with `node_modules/@types/sizzle`. See: https://github.com/eslint/eslint/pull/19643/files#r2155194866

#### What changes did you make? (Give an overview)

Enables [`skipLibCheck`](https://aka.ms/tsconfig#skipLibCheck) to prevent type checking of external `.d.ts` files.

#### Related Issues

* https://github.com/eslint/eslint/pull/19643/files#r2155194866 
* https://github.com/DefinitelyTyped/DefinitelyTyped/pull/73082

#### Is there anything you'd like reviewers to focus on?
