### PR TITLE
refactor: use `CustomRuleDefinitionType` in `CSSRuleDefinition`

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "@eslint/core": "^0.14.0",
+    "@eslint/core": "^0.15.0",
     "@eslint/css-tree": "^3.6.1",
     "@eslint/plugin-kit": "^0.3.1"
   },

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,11 @@
 // Imports
 //------------------------------------------------------------------------------
 
-import type { RuleVisitor, RuleDefinition } from "@eslint/core";
+import type {
+	CustomRuleDefinitionType,
+	CustomRuleTypeDefinitions,
+	RuleVisitor,
+} from "@eslint/core";
 
 import type { CssNodePlain, CssNodeNames } from "@eslint/css-tree";
 
@@ -46,28 +50,19 @@ export interface CSSRuleVisitor
 	extends RuleVisitor,
 		Partial<WithExit<CSSNodeVisitor>> {}
 
-export type CSSRuleDefinitionTypeOptions = {
-	RuleOptions: unknown[];
-	MessageIds: string;
-	ExtRuleDocs: Record<string, unknown>;
-};
+export type CSSRuleDefinitionTypeOptions = CustomRuleTypeDefinitions;
 
 /**
  * A rule definition for CSS.
  */
 export type CSSRuleDefinition<
 	Options extends Partial<CSSRuleDefinitionTypeOptions> = {},
-> = RuleDefinition<
-	// Language specific type options (non-configurable)
+> = CustomRuleDefinitionType<
 	{
 		LangOptions: CSSLanguageOptions;
 		Code: CSSSourceCode;
 		Visitor: CSSRuleVisitor;
 		Node: CssNodePlain;
-	} & Required<
-		// Rule specific type options (custom)
-		Options &
-			// Rule specific type options (defaults)
-			Omit<CSSRuleDefinitionTypeOptions, keyof Options>
-	>
+	},
+	Options
 >;


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Simplify type definitions.

#### What changes did you make? (Give an overview)

* Refactored the type definition of `CSSRuleDefinition` using the core [`CustomRuleDefinitionType`](https://github.com/eslint/rewrite/blob/core-v0.15.0/packages/core/src/types.ts#L598-L631) type.
* Redefined `CSSRuleDefinitionTypeOptions` as an alias for the core [`CustomRuleTypeDefinitions`](https://github.com/eslint/rewrite/blob/core-v0.15.0/packages/core/src/types.ts#L589-L596) type.
* Also upgraded `@eslint/core` to v0.15.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

refs eslint/rewrite#177

Related PRs: eslint/eslint#19949, eslint/json#121, eslint/markdown#471

#### Is there anything you'd like reviewers to focus on?
