### PR TITLE
fix: Ensure languageOptions.customSyntax is serializable

### DIFF
--- a/tests/languages/css-language.test.js
+++ b/tests/languages/css-language.test.js
@@ -261,4 +261,64 @@ describe("CSSLanguage", () => {
 			assert.strictEqual(sourceCode.comments.length, 1);
 		});
 	});
+
+	describe("normalizeLanguageOptions", () => {
+		it("should return the same object if no customSyntax is present", () => {
+			const language = new CSSLanguage();
+			const options = { tolerant: true };
+			const result = language.normalizeLanguageOptions(options);
+			assert.strictEqual(result, options);
+			assert.strictEqual(typeof result.toJSON, "undefined");
+		});
+
+		it("should add a toJSON method if customSyntax is present", () => {
+			const language = new CSSLanguage();
+			const options = { tolerant: true, customSyntax: { foo: "bar" } };
+			const result = language.normalizeLanguageOptions(options);
+			assert.strictEqual(result, options);
+			assert.strictEqual(typeof result.toJSON, "function");
+		});
+
+		it("should replace functions with true in toJSON output", () => {
+			const language = new CSSLanguage();
+			const options = {
+				tolerant: false,
+				customSyntax: {
+					node: {
+						foo() {},
+						bar: 42,
+						baz: {
+							qux() {},
+						},
+					},
+					scope: {
+						test() {},
+					},
+					atrule: {
+						other() {},
+					},
+				},
+			};
+			language.normalizeLanguageOptions(options);
+			const json = options.toJSON();
+			assert.deepStrictEqual(json, {
+				tolerant: false,
+				customSyntax: {
+					node: {
+						foo: true,
+						bar: 42,
+						baz: {
+							qux: true,
+						},
+					},
+					scope: {
+						test: true,
+					},
+					atrule: {
+						other: true,
+					},
+				},
+			});
+		});
+	});
 });

--- a/tests/plugin/eslint.test.js
+++ b/tests/plugin/eslint.test.js
@@ -101,6 +101,89 @@ describe("Plugin", () => {
 				assert.strictEqual(results[0].messages[1].column, 18);
 			});
 		});
+
+		describe("serialization", () => {
+			it("should serialize the config to JSON", async () => {
+				const languageOptions = {
+					tolerant: true,
+				};
+
+				const configWithLanguageOptions = {
+					...config,
+					languageOptions,
+				};
+
+				const eslint = new ESLint({
+					overrideConfigFile: true,
+					overrideConfig: configWithLanguageOptions,
+				});
+
+				const resultConfig =
+					await eslint.calculateConfigForFile("test.css");
+				const serializedConfig = JSON.stringify(
+					resultConfig.languageOptions,
+					null,
+					2,
+				);
+				const expectedConfig = JSON.stringify(languageOptions, null, 2);
+				assert.strictEqual(serializedConfig, expectedConfig);
+			});
+
+			it("should serialize the config to JSON when it has functions", async () => {
+				const languageOptions = {
+					tolerant: true,
+					customSyntax: {
+						node: {
+							CustomNode: {
+								parse() {},
+							},
+						},
+						scope: {
+							Value: {
+								theme() {},
+							},
+						},
+						atrule: {
+							CustomAtRule: {
+								parse: {
+									prelude() {},
+								},
+							},
+						},
+					},
+				};
+
+				const configWithLanguageOptions = {
+					...config,
+					languageOptions,
+				};
+
+				const eslint = new ESLint({
+					overrideConfigFile: true,
+					overrideConfig: configWithLanguageOptions,
+				});
+
+				const resultConfig =
+					await eslint.calculateConfigForFile("test.css");
+				const serializedConfig = JSON.stringify(
+					resultConfig.languageOptions,
+					null,
+					2,
+				);
+				const expectedConfig = JSON.stringify(
+					languageOptions,
+					(key, value) => {
+						if (typeof value === "function") {
+							return true;
+						}
+
+						return value;
+					},
+					2,
+				);
+				assert.strictEqual(serializedConfig, expectedConfig);
+			});
+		});
 	});
 
 	describe("Configuration Comments", () => {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Ensures that `languageOptions.customSyntax` is serializable by replacing all functions with `true`. CSSTree allows functions in its config and we need to account for that to allow things like caching in ESLint.

#### What changes did you make? (Give an overview)

- Added `CSSLanguage#normalizeLanguageOptions()` that adds a `toJSON` method when the `customSyntax` option is present
- Updated the `CSSLanguage` tests to validate the new functionality works.
- Updated the plugin test to ensure we get the expected results when run through ESLint.

#### Related Issues

fixes #211

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
