### PR TITLE
feat: add autofix to no-duplicate-imports rule

### DIFF
--- a/src/rules/no-duplicate-imports.js
+++ b/src/rules/no-duplicate-imports.js
@@ -24,6 +24,8 @@ export default {
 	meta: {
 		type: "problem",
 
+		fixable: "code",
+
 		docs: {
 			description: "Disallow duplicate @import rules",
 			recommended: true,
@@ -36,6 +38,7 @@ export default {
 	},
 
 	create(context) {
+		const { sourceCode } = context;
 		const imports = new Set();
 
 		return {
@@ -47,6 +50,13 @@ export default {
 						loc: node.loc,
 						messageId: "duplicateImport",
 						data: { url },
+						fix(fixer) {
+							const [start, end] = sourceCode.getRange(node);
+							// Remove the node, and also remove a following newline if present
+							const removeEnd =
+								sourceCode.text[end] === "\n" ? end + 1 : end;
+							return fixer.removeRange([start, removeEnd]);
+						},
 					});
 				} else {
 					imports.add(url);

--- a/tests/rules/no-duplicate-imports.test.js
+++ b/tests/rules/no-duplicate-imports.test.js
@@ -129,5 +129,33 @@ ruleTester.run("no-duplicate-imports", rule, {
 				},
 			],
 		},
+		{
+			code: "@import url('a.css');\n@import url('b.css');\n@import url('c.css');\n@import url('a.css');\n@import url('d.css');",
+			output: "@import url('a.css');\n@import url('b.css');\n@import url('c.css');\n@import url('d.css');",
+			errors: [
+				{
+					messageId: "duplicateImport",
+					data: { url: "a.css" },
+					line: 4,
+					column: 1,
+					endLine: 4,
+					endColumn: 22,
+				},
+			],
+		},
+		{
+			code: "@import url('a.css');\n@import url('b.css');\n/* comment */\n@import 'a.css';",
+			output: "@import url('a.css');\n@import url('b.css');\n/* comment */\n",
+			errors: [
+				{
+					messageId: "duplicateImport",
+					data: { url: "a.css" },
+					line: 4,
+					column: 1,
+					endLine: 4,
+					endColumn: 17,
+				},
+			],
+		},
 	],
 });

--- a/tests/rules/no-duplicate-imports.test.js
+++ b/tests/rules/no-duplicate-imports.test.js
@@ -31,6 +31,7 @@ ruleTester.run("no-duplicate-imports", rule, {
 	invalid: [
 		{
 			code: "@import url('x.css');\n@import url('x.css');",
+			output: "@import url('x.css');\n",
 			errors: [
 				{
 					messageId: "duplicateImport",
@@ -43,7 +44,36 @@ ruleTester.run("no-duplicate-imports", rule, {
 			],
 		},
 		{
+			code: "@import url('x.css');@import url('x.css');",
+			output: "@import url('x.css');",
+			errors: [
+				{
+					messageId: "duplicateImport",
+					data: { url: "x.css" },
+					line: 1,
+					column: 22,
+					endLine: 1,
+					endColumn: 43,
+				},
+			],
+		},
+		{
+			code: "@import url('x.css');@import url('x.css');@import url('y.css')",
+			output: "@import url('x.css');@import url('y.css')",
+			errors: [
+				{
+					messageId: "duplicateImport",
+					data: { url: "x.css" },
+					line: 1,
+					column: 22,
+					endLine: 1,
+					endColumn: 43,
+				},
+			],
+		},
+		{
 			code: "@import url('x.css');\n@import 'x.css';",
+			output: "@import url('x.css');\n",
 			errors: [
 				{
 					messageId: "duplicateImport",
@@ -57,6 +87,7 @@ ruleTester.run("no-duplicate-imports", rule, {
 		},
 		{
 			code: "@import url('x.css');\n@import 'x.css';\n@import 'x.css';",
+			output: "@import url('x.css');\n@import 'x.css';",
 			errors: [
 				{
 					messageId: "duplicateImport",
@@ -78,6 +109,7 @@ ruleTester.run("no-duplicate-imports", rule, {
 		},
 		{
 			code: "@import url('x.css');\n@import 'x.css';\n@import url('y.css');\n@import 'y.css';",
+			output: "@import url('x.css');\n@import url('y.css');\n",
 			errors: [
 				{
 					messageId: "duplicateImport",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This pull request adds autofix support to the `no-duplicate-imports` rule. The goal is to allow users to automatically remove duplicate `@import` statements in their CSS files.

#### What changes did you make? (Give an overview)

- Updated the `no-duplicate-imports` rule to provide an autofix that removes duplicate `@import` statements
- Added and updated tests to verify that autofix works correctly

#### Related Issues

Fixes #205

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
