### PR TITLE
fix: make relative-font-units unit matching case-insensitive

### DIFF
--- a/src/rules/relative-font-units.js
+++ b/src/rules/relative-font-units.js
@@ -103,7 +103,9 @@ export default {
 
 						if (
 							(value.type === "Dimension" &&
-								!allowedFontUnits.includes(value.unit)) ||
+								!allowedFontUnits.includes(
+									value.unit.toLowerCase(),
+								)) ||
 							(value.type === "Identifier" &&
 								disallowedFontSizeKeywords.has(
 									value.name.toLowerCase(),
@@ -161,7 +163,7 @@ export default {
 								check:
 									dimensionNode &&
 									!allowedFontUnits.includes(
-										dimensionNode.unit,
+										dimensionNode.unit.toLowerCase(),
 									),
 								loc: dimensionNode?.loc,
 							},

--- a/tests/rules/relative-font-units.test.js
+++ b/tests/rules/relative-font-units.test.js
@@ -28,6 +28,11 @@ ruleTester.run("relative-font-units", rule, {
 		"a { font-size: 1rem; }",
 		"a { font: 2rem Arial, sans-serif; }",
 		"a { font: 1.2rem/2 Arial, sans-serif; }",
+		"a { font-size: 1REM; }",
+		"a { font-size: 1Rem; }",
+		"a { font-size: 1rEm; }",
+		"a { font: 2REM Arial, sans-serif; }",
+		"a { font: 1.2REM/2 Arial, sans-serif; }",
 		"a { font-size: var(--foo); }",
 		"a { font: var(--foo) Arial; }",
 		"a { font-size: calc(10px + 2px); }",
@@ -220,6 +225,76 @@ ruleTester.run("relative-font-units", rule, {
 					allowUnits: ["rem", "em"],
 				},
 			],
+		},
+		{
+			code: "a { font-size: 1EM; }",
+			options: [{ allowUnits: ["em"] }],
+		},
+		{
+			code: "a { font: 2EM Arial, sans-serif; }",
+			options: [{ allowUnits: ["em"] }],
+		},
+		{
+			code: "a { font-size: 2CAP; }",
+			options: [{ allowUnits: ["cap"] }],
+		},
+		{
+			code: "a { font-size: 20CH; }",
+			options: [{ allowUnits: ["ch"] }],
+		},
+		{
+			code: "a { font-size: 3EX; }",
+			options: [{ allowUnits: ["ex"] }],
+		},
+		{
+			code: "a { font-size: 2IC; }",
+			options: [{ allowUnits: ["ic"] }],
+		},
+		{
+			code: "a { font-size: 1LH; }",
+			options: [{ allowUnits: ["lh"] }],
+		},
+		{
+			code: "a { font-size: 2RCAP; }",
+			options: [{ allowUnits: ["rcap"] }],
+		},
+		{
+			code: "a { font-size: 20RCH; }",
+			options: [{ allowUnits: ["rch"] }],
+		},
+		{
+			code: "a { font-size: 2REX; }",
+			options: [{ allowUnits: ["rex"] }],
+		},
+		{
+			code: "a { font-size: 1.5RIC; }",
+			options: [{ allowUnits: ["ric"] }],
+		},
+		{
+			code: "a { font-size: 1RLH; }",
+			options: [{ allowUnits: ["rlh"] }],
+		},
+		{
+			code: dedent`
+				a {
+					font-size: 1REM;
+				}
+				b {
+					font-size: 1Em;
+				}
+			`,
+			options: [{ allowUnits: ["rem", "em"] }],
+		},
+		{
+			code: dedent`
+				a {
+					font: 2REM Arial, sans-serif;
+				}
+				b {
+					font: 1.5EM "Helvetica", sans-serif;
+				}
+			`,
+			options: [{ allowUnits: ["rem", "em"] }],
 		},
 		{
 			code: "a { font-size: smaller; }",
@@ -490,6 +565,40 @@ ruleTester.run("relative-font-units", rule, {
 					messageId: "allowedFontUnits",
 				},
 			],
+		},
+		{
+			code: "a { font-size: 1PX; }",
+			errors: [{ messageId: "allowedFontUnits" }],
+		},
+		{
+			code: "a { font-size: 1IN; }",
+			errors: [{ messageId: "allowedFontUnits" }],
+		},
+		{
+			code: "a { font-size: 1CM; }",
+			errors: [{ messageId: "allowedFontUnits" }],
+		},
+		{
+			code: "a { font-size: 1MM; }",
+			errors: [{ messageId: "allowedFontUnits" }],
+		},
+		{
+			code: "a { font-size: 1PT; }",
+			errors: [{ messageId: "allowedFontUnits" }],
+		},
+		{
+			code: "a { font-size: 1PC; }",
+			errors: [{ messageId: "allowedFontUnits" }],
+		},
+		{
+			code: "a { font-size: 1EM; }",
+			options: [{ allowUnits: ["rem"] }],
+			errors: [{ messageId: "allowedFontUnits" }],
+		},
+		{
+			code: "a { font: 2EM Arial, sans-serif; }",
+			options: [{ allowUnits: ["rem"] }],
+			errors: [{ messageId: "allowedFontUnits" }],
 		},
 		{
 			code: "a { font-size: xx-small; }",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This PR fixes a false positive error in the `relative-font-units` rule where uppercase CSS units like 1REM, 1EM, etc. were being incorrectly flagged as errors. According to the CSS specification, units are case-insensitive, so REM should be equivalent to rem.

#### What changes did you make? (Give an overview)

- Modified the `relative-font-units` rule to convert the CSS units to lowercase before comparison
- Added test cases to verify case-insensitive unit matching works correctly

#### Related Issues

Fixes #215

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
