### PR TITLE
chore: add `.c8rc` file

### DIFF
--- a/.c8rc
+++ b/.c8rc
@@ -1,0 +1,5 @@
+{
+	"include": ["src/**/*.js"],
+	"reporter": ["lcov", "text-summary", "cobertura"],
+	"sourceMap": true
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -31,7 +31,7 @@ const eslintPluginTestsRecommendedConfig =
 //-----------------------------------------------------------------------------
 
 export default defineConfig([
-	globalIgnores(["**/tests/fixtures/", "**/dist/", "test.css"]),
+	globalIgnores(["**/tests/fixtures/", "**/dist/", "test.css", "coverage/"]),
 
 	...eslintConfigESLint.map(config => ({
 		files: ["**/*.js"],
@@ -39,8 +39,7 @@ export default defineConfig([
 	})),
 	{
 		plugins: { json },
-		files: ["**/*.json"],
-		ignores: ["**/package-lock.json"],
+		files: ["**/*.json", ".c8rc"],
 		language: "json/json",
 		extends: ["json/recommended"],
 	},

--- a/package.json
+++ b/package.json
@@ -71,8 +71,8 @@
     "fmt": "prettier --write .",
     "fmt:check": "prettier --check .",
     "test": "mocha tests/**/*.js",
-    "test:jsr": "npx jsr@latest publish --dry-run",
     "test:coverage": "c8 npm test",
+    "test:jsr": "npx jsr@latest publish --dry-run",
     "test:types": "npm run build && tsc -p tests/types/tsconfig.json"
   },
   "keywords": [
@@ -90,7 +90,7 @@
   },
   "devDependencies": {
     "@eslint/json": "^0.13.0",
-    "c8": "^9.1.0",
+    "c8": "^10.1.3",
     "compute-baseline": "^0.3.1",
     "dedent": "^1.5.3",
     "eslint": "^9.31.0",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This pull request add a `.c8rc` similar to the one in `eslint/eslint` or `eslint/rewrite`. When `npm run test:coverage` is run, coverage reports will be generated in the `coverage` folder that can be used to find parts of code that are not covered by unit tests.

#### What changes did you make? (Give an overview)

* Added `.c8rc` file
* Updated ESLint config to make sure that the `.c8rc` file is linted as JSON, and to ignore the `coverage` folder.
* Updated c8 to the latest version

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
