### PR TITLE
fix(no-invalid-properties): incorrect report when var is used inside calc fn

### DIFF
--- a/src/rules/no-invalid-properties.js
+++ b/src/rules/no-invalid-properties.js
@@ -166,8 +166,22 @@ export default {
 					// When `var()` is used, we store all the values to `valueList` with the replacement of `var()` with there values or fallback values
 					for (const child of valueNodes) {
 						// If value is a function starts with `var()`
-						if (child.type === "Function" && child.name === "var") {
-							const varValue = vars.get(child.children[0].name);
+						if (
+							child.type === "Function" &&
+							(child.name === "var" || child.name === "calc")
+						) {
+							const isCalcFn = child.name === "calc";
+
+							const varFn = isCalcFn
+								? child.children.find(
+										c =>
+											c.type === "Function" &&
+											c.name === "var",
+									)
+								: child;
+
+							const varName = varFn.children[0].name;
+							const varValue = vars.get(varName);
 
 							// If the variable is found, use its value, otherwise check for fallback values
 							if (varValue) {

--- a/tests/rules/no-invalid-properties.test.js
+++ b/tests/rules/no-invalid-properties.test.js
@@ -77,7 +77,8 @@ ruleTester.run("no-invalid-properties", rule, {
 			code: ":root { --color: red }\na { border-top: 1px var(--style, var(--fallback)) var(--color, blue); }",
 			options: [{ allowUnknownVariables: true }],
 		},
-
+		":root { --width: 10px; }\ndiv { width: calc(100% - var(--width)) }",
+		":root { --sm: 10px; --m: 20px; }\ndiv { font-size: calc(100px - var(--sm) - var(--m)); }",
 		/*
 		 * CSSTree doesn't currently support custom functions properly, so leaving
 		 * these out for now.


### PR DESCRIPTION

<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Fixes #223 

#### What changes did you make? (Give an overview)

Handle the cases when `var` is used inside `calc` fn


#### Related Issues

Fixes #223

#### Is there anything you'd like reviewers to focus on?
