### PR TITLE
fix: allow any type for `meta.docs.recommended` in custom rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,12 +84,12 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "@eslint/core": "^0.15.1",
-    "@eslint/css-tree": "^3.6.2",
-    "@eslint/plugin-kit": "^0.3.4"
+    "@eslint/core": "^0.15.2",
+    "@eslint/css-tree": "^3.6.3",
+    "@eslint/plugin-kit": "^0.3.5"
   },
   "devDependencies": {
-    "@eslint/json": "^0.13.0",
+    "@eslint/json": "^0.13.1",
     "c8": "^10.1.3",
     "compute-baseline": "^0.3.1",
     "dedent": "^1.5.3",
@@ -106,7 +106,7 @@
     "rollup-plugin-copy": "^3.5.0",
     "rollup-plugin-delete": "^3.0.1",
     "tailwind-csstree": "^0.1.0",
-    "typescript": "^5.8.2",
+    "typescript": "^5.9.2",
     "web-features": "^2.43.0",
     "yorkie": "^2.0.0"
   },

--- a/tests/types/types.test.ts
+++ b/tests/types/types.test.ts
@@ -273,3 +273,18 @@ css.configs.recommended.plugins satisfies object;
 		return {};
 	},
 });
+
+// `meta.docs.recommended` can be any type
+(): CSSRuleDefinition => ({
+	create() {
+		return {};
+	},
+	meta: {
+		docs: {
+			recommended: {
+				severity: "warn",
+				options: ["never"],
+			},
+		},
+	},
+});


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Hi,

This PR is follow-up to https://github.com/eslint/eslint/pull/19995.

You can find more details about this change in https://github.com/eslint/rewrite/issues/234.

#### What changes did you make? (Give an overview)

- Updated `@eslint/core` to allow arbitrary types for `meta.docs.recommended` in custom rules.
- Upgraded other dependencies to the latest versions.
- Updated type tests.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
