### PR TITLE
fix: treat at-rule names as case-insensitive across rules

### DIFF
--- a/src/rules/no-duplicate-imports.js
+++ b/src/rules/no-duplicate-imports.js
@@ -42,7 +42,7 @@ export default {
 		const imports = new Set();
 
 		return {
-			"Atrule[name=import]"(node) {
+			"Atrule[name=/^import$/i]"(node) {
 				const url = node.prelude.children[0].value;
 
 				if (imports.has(url)) {

--- a/src/rules/no-duplicate-keyframe-selectors.js
+++ b/src/rules/no-duplicate-keyframe-selectors.js
@@ -39,12 +39,12 @@ export default {
 		const seen = new Map();
 
 		return {
-			"Atrule[name=keyframes]"() {
+			"Atrule[name=/^keyframes$/i]"() {
 				insideKeyframes = true;
 				seen.clear();
 			},
 
-			"Atrule[name=keyframes]:exit"() {
+			"Atrule[name=/^keyframes$/i]:exit"() {
 				insideKeyframes = false;
 			},
 

--- a/src/rules/use-baseline.js
+++ b/src/rules/use-baseline.js
@@ -527,11 +527,11 @@ export default {
 		}
 
 		return {
-			"Atrule[name=supports]"() {
+			"Atrule[name=/^supports$/i]"() {
 				supportsRules.push(new SupportsRule());
 			},
 
-			"Atrule[name=supports] > AtrulePrelude > Condition"(node) {
+			"Atrule[name=/^supports$/i] > AtrulePrelude > Condition"(node) {
 				const supportsRule = supportsRules.last();
 
 				for (let i = 0; i < node.children.length; i++) {
@@ -667,11 +667,11 @@ export default {
 				}
 			},
 
-			"Atrule[name=supports]:exit"() {
+			"Atrule[name=/^supports$/i]:exit"() {
 				supportsRules.pop();
 			},
 
-			"Atrule[name=media] > AtrulePrelude > MediaQueryList > MediaQuery > Condition"(
+			"Atrule[name=/^media$/i] > AtrulePrelude > MediaQueryList > MediaQuery > Condition"(
 				node,
 			) {
 				for (const child of node.children) {
@@ -719,11 +719,12 @@ export default {
 
 			Atrule(node) {
 				// ignore unknown at-rules - no-invalid-at-rules already catches this
-				if (!atRules.has(node.name)) {
+				const atRuleName = node.name.toLowerCase();
+				if (!atRules.has(atRuleName)) {
 					return;
 				}
 
-				const featureStatus = atRules.get(node.name);
+				const featureStatus = atRules.get(atRuleName);
 
 				if (!baselineAvailability.isSupported(featureStatus)) {
 					const loc = node.loc;

--- a/src/rules/use-layers.js
+++ b/src/rules/use-layers.js
@@ -75,7 +75,7 @@ export default {
 			: null;
 
 		return {
-			"Atrule[name=import]"(node) {
+			"Atrule[name=/^import$/i]"(node) {
 				// layer, if present, must always be the second child of the prelude
 				const secondChild = node.prelude.children[1];
 				const layerNode =
@@ -140,7 +140,7 @@ export default {
 				});
 			},
 
-			"Atrule[name=layer]"(node) {
+			"Atrule[name=/^layer$/i]"(node) {
 				layerDepth++;
 
 				if (!options.allowUnnamedLayers && !node.prelude) {
@@ -151,7 +151,7 @@ export default {
 				}
 			},
 
-			"Atrule[name=layer]:exit"() {
+			"Atrule[name=/^layer$/i]:exit"() {
 				layerDepth--;
 			},
 

--- a/tests/rules/no-duplicate-imports.test.js
+++ b/tests/rules/no-duplicate-imports.test.js
@@ -27,6 +27,9 @@ ruleTester.run("no-duplicate-imports", rule, {
 		"@import url('x.css');",
 		"@import url('x.css'); @import url('y.css');",
 		"@import 'x.css'; @import url('y.css'); @import 'z.css';",
+		"@IMPORT url('x.css');",
+		"@imPort url('x.css'); @IMport url('y.css');",
+		"@IMPORT 'x.css'; @import url('y.css'); @IMport 'z.css';",
 	],
 	invalid: [
 		{
@@ -154,6 +157,84 @@ ruleTester.run("no-duplicate-imports", rule, {
 					column: 1,
 					endLine: 4,
 					endColumn: 17,
+				},
+			],
+		},
+		{
+			code: "@IMPORT url('x.css');\n@IMPORT url('x.css');",
+			output: "@IMPORT url('x.css');\n",
+			errors: [
+				{
+					messageId: "duplicateImport",
+					data: { url: "x.css" },
+					line: 2,
+					column: 1,
+					endLine: 2,
+					endColumn: 22,
+				},
+			],
+		},
+		{
+			code: "@IMport url('x.css');@IMPORT url('x.css');",
+			output: "@IMport url('x.css');",
+			errors: [
+				{
+					messageId: "duplicateImport",
+					data: { url: "x.css" },
+					line: 1,
+					column: 22,
+					endLine: 1,
+					endColumn: 43,
+				},
+			],
+		},
+		{
+			code: "@IMPORT url('x.css');@IMPORT url('x.css');@IMPORT url('y.css')",
+			output: "@IMPORT url('x.css');@IMPORT url('y.css')",
+			errors: [
+				{
+					messageId: "duplicateImport",
+					data: { url: "x.css" },
+					line: 1,
+					column: 22,
+					endLine: 1,
+					endColumn: 43,
+				},
+			],
+		},
+		{
+			code: "@IMPORT url('x.css');\n@IMPORT 'x.css';\n@IMPORT 'x.css';",
+			output: "@IMPORT url('x.css');\n@IMPORT 'x.css';",
+			errors: [
+				{
+					messageId: "duplicateImport",
+					data: { url: "x.css" },
+					line: 2,
+					column: 1,
+					endLine: 2,
+					endColumn: 17,
+				},
+				{
+					messageId: "duplicateImport",
+					data: { url: "x.css" },
+					line: 3,
+					column: 1,
+					endLine: 3,
+					endColumn: 17,
+				},
+			],
+		},
+		{
+			code: "@IMPORT url('a.css');\n@import url('b.css');\n@IMPORT url('c.css');\n@import url('a.css');\n@IMPORT url('d.css');",
+			output: "@IMPORT url('a.css');\n@import url('b.css');\n@IMPORT url('c.css');\n@IMPORT url('d.css');",
+			errors: [
+				{
+					messageId: "duplicateImport",
+					data: { url: "a.css" },
+					line: 4,
+					column: 1,
+					endLine: 4,
+					endColumn: 22,
 				},
 			],
 		},

--- a/tests/rules/no-duplicate-keyframe-selectors.test.js
+++ b/tests/rules/no-duplicate-keyframe-selectors.test.js
@@ -52,6 +52,19 @@ ruleTester.run("no-duplicate-keyframe-selectors", rule, {
             0% { opacity: 0; }
             0.0% { opacity: 1; }
         }`,
+		dedent`@KEYFRAMES test {
+			from { opacity: 0; }
+			to { opacity: 1; }
+		}`,
+		dedent`@KeYFrames test {
+            0% { opacity: 0; }
+            100% { opacity: 1; }
+        }`,
+		dedent`@Keyframes test {
+            from { opacity: 0; }
+            50% { opacity: 0.5; }
+            to { opacity: 1; }
+        }`,
 	],
 	invalid: [
 		{
@@ -242,6 +255,68 @@ ruleTester.run("no-duplicate-keyframe-selectors", rule, {
 					column: 5,
 					endLine: 5,
 					endColumn: 7,
+				},
+			],
+		},
+		{
+			code: dedent`@KEYFRAMES test {
+                0% { opacity: 0; }
+                0% { opacity: 1; }
+            }`,
+			errors: [
+				{
+					messageId: "duplicateKeyframeSelector",
+					line: 3,
+					column: 5,
+					endLine: 3,
+					endColumn: 7,
+				},
+			],
+		},
+		{
+			code: dedent`@Keyframes test {
+                0% {
+                    opacity: 0;
+                }
+
+                0% {
+                    opacity: 1;
+                }
+
+                50% {
+                    opacity: 0.5;
+                }
+
+                50% {
+                    opacity: 0.75;
+                }
+
+                50% {
+                    opacity: 0.5;
+                }
+
+            }`,
+			errors: [
+				{
+					messageId: "duplicateKeyframeSelector",
+					line: 6,
+					column: 5,
+					endLine: 6,
+					endColumn: 7,
+				},
+				{
+					messageId: "duplicateKeyframeSelector",
+					line: 14,
+					column: 5,
+					endLine: 14,
+					endColumn: 8,
+				},
+				{
+					messageId: "duplicateKeyframeSelector",
+					line: 18,
+					column: 5,
+					endLine: 18,
+					endColumn: 8,
 				},
 			],
 		},

--- a/tests/rules/use-baseline.test.js
+++ b/tests/rules/use-baseline.test.js
@@ -36,6 +36,9 @@ ruleTester.run("use-baseline", rule, {
 		"@media (min-width: 800px) { a { color: red; } }",
 		"@media (foo) { a { color: red; } }",
 		"@media (prefers-color-scheme: dark) { a { color: red; } }",
+		"@MEDIA (min-width: 800px) { a { color: red; } }",
+		"@Media (foo) { a { color: red; } }",
+		"@MeDia (prefers-color-scheme: dark) { a { color: red; } }",
 		"@supports (accent-color: auto) { a { accent-color: auto; } }",
 		"@supports (accent-color: red) { a { accent-color: red; } }",
 		"@supports (accent-color: auto) { a { accent-color: red; } }",
@@ -45,6 +48,15 @@ ruleTester.run("use-baseline", rule, {
 		}`,
 		`@supports (accent-color: auto) {
 			@supports (backdrop-filter: auto) {
+				a { accent-color: auto; background-filter: auto }
+			}
+		}`,
+		"@SUPPORTS (clip-path: fill-box) { a { clip-path: fill-box; } }",
+		`@Supports (accent-color: auto) and (backdrop-filter: auto) {
+			a { accent-color: auto; background-filter: auto }
+		}`,
+		`@SUPPORTS (accent-color: auto) {
+			@SuPpOrTs (backdrop-filter: auto) {
 				a { accent-color: auto; background-filter: auto }
 			}
 		}`,
@@ -191,6 +203,23 @@ ruleTester.run("use-baseline", rule, {
 			],
 		},
 		{
+			code: "@VIEW-TRANSITION { from-view: a; to-view: b; }",
+			options: [{ available: "newly" }],
+			errors: [
+				{
+					messageId: "notBaselineAtRule",
+					data: {
+						atRule: "VIEW-TRANSITION",
+						availability: "newly",
+					},
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 17,
+				},
+			],
+		},
+		{
 			code: dedent`@supports (accent-color: auto) {
 				@supports (backdrop-filter: auto) {
 					a { accent-color: red; }
@@ -213,7 +242,46 @@ ruleTester.run("use-baseline", rule, {
 			],
 		},
 		{
+			code: dedent`@SUPPORTS (accent-color: auto) {
+				@SuPpOrTs (backdrop-filter: auto) {
+					a { accent-color: red; }
+				}
+
+				a { backdrop-filter: auto; }
+			}`,
+			errors: [
+				{
+					messageId: "notBaselineProperty",
+					data: {
+						property: "backdrop-filter",
+						availability: "widely",
+					},
+					line: 6,
+					column: 6,
+					endLine: 6,
+					endColumn: 21,
+				},
+			],
+		},
+		{
 			code: "@supports (clip-path: fill-box) { a { clip-path: stroke-box; } }",
+			errors: [
+				{
+					messageId: "notBaselinePropertyValue",
+					data: {
+						property: "clip-path",
+						value: "stroke-box",
+						availability: "widely",
+					},
+					line: 1,
+					column: 50,
+					endLine: 1,
+					endColumn: 60,
+				},
+			],
+		},
+		{
+			code: "@SUPPORTS (clip-path: fill-box) { a { clip-path: stroke-box; } }",
 			errors: [
 				{
 					messageId: "notBaselinePropertyValue",
@@ -295,6 +363,22 @@ ruleTester.run("use-baseline", rule, {
 		},
 		{
 			code: "@media (color-gamut: srgb) { a { color: red; } }",
+			errors: [
+				{
+					messageId: "notBaselineMediaCondition",
+					data: {
+						condition: "color-gamut",
+						availability: "widely",
+					},
+					line: 1,
+					column: 9,
+					endLine: 1,
+					endColumn: 20,
+				},
+			],
+		},
+		{
+			code: "@MEDIA (color-gamut: srgb) { a { color: red; } }",
 			errors: [
 				{
 					messageId: "notBaselineMediaCondition",

--- a/tests/rules/use-layers.test.js
+++ b/tests/rules/use-layers.test.js
@@ -35,6 +35,16 @@ ruleTester.run("use-layers", rule, {
 				}
 			}
 		`,
+		"@LAYER bar { a { color: red; } }",
+		"@Layer foo { a { color: red; } }",
+		"@IMPORT 'foo.css' layer(foo);",
+		dedent`
+			@media (min-width: 600px) {
+				@LAYER foo {
+					a { color: bar }
+				}
+			}
+		`,
 		dedent`
 			@media (min-width: 600px) {
 				@layer foo {
@@ -50,6 +60,10 @@ ruleTester.run("use-layers", rule, {
 			options: [{ allowUnnamedLayers: true }],
 		},
 		{
+			code: "@LAYER { a { color: red; } }",
+			options: [{ allowUnnamedLayers: true }],
+		},
+		{
 			code: "@import 'foo.css' layer;",
 			options: [{ allowUnnamedLayers: true }],
 		},
@@ -58,7 +72,15 @@ ruleTester.run("use-layers", rule, {
 			options: [{ requireImportLayers: false }],
 		},
 		{
+			code: "@IMPORT 'foo.css';",
+			options: [{ requireImportLayers: false }],
+		},
+		{
 			code: "@layer foo.bar { a { color: red; } }",
+			options: [{ layerNamePattern: "^(foo|bar)$" }],
+		},
+		{
+			code: "@LAYER foo.bar { a { color: red; } }",
 			options: [{ layerNamePattern: "^(foo|bar)$" }],
 		},
 		{
@@ -133,6 +155,28 @@ ruleTester.run("use-layers", rule, {
 		},
 		{
 			code: dedent`
+				@LAYER { a { color: red; } }
+				a { color: bar }
+			`,
+			errors: [
+				{
+					messageId: "missingLayerName",
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 29,
+				},
+				{
+					messageId: "missingLayer",
+					line: 2,
+					column: 1,
+					endLine: 2,
+					endColumn: 17,
+				},
+			],
+		},
+		{
+			code: dedent`
 				@media (min-width: 600px) {
 					a { color: bar }
 				}
@@ -172,6 +216,18 @@ ruleTester.run("use-layers", rule, {
 		},
 		{
 			code: "@import 'foo.css';",
+			errors: [
+				{
+					messageId: "missingImportLayer",
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 19,
+				},
+			],
+		},
+		{
+			code: "@IMPORT 'foo.css';",
 			errors: [
 				{
 					messageId: "missingImportLayer",
@@ -224,6 +280,34 @@ ruleTester.run("use-layers", rule, {
 		},
 		{
 			code: "@layer foo, bar, baz;",
+			options: [{ layerNamePattern: "bar" }],
+			errors: [
+				{
+					messageId: "layerNameMismatch",
+					data: {
+						name: "foo",
+						pattern: "bar",
+					},
+					line: 1,
+					column: 8,
+					endLine: 1,
+					endColumn: 11,
+				},
+				{
+					messageId: "layerNameMismatch",
+					data: {
+						name: "baz",
+						pattern: "bar",
+					},
+					line: 1,
+					column: 18,
+					endLine: 1,
+					endColumn: 21,
+				},
+			],
+		},
+		{
+			code: "@LAYER foo, bar, baz;",
 			options: [{ layerNamePattern: "bar" }],
 			errors: [
 				{


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Ensure at-rule names are treated case-insensitively across rules, aligning with CSS syntax and preventing missed detections when authors use mixed-case at-rules.

#### What changes did you make? (Give an overview)

- Updated rule listeners to use case-insensitive matching
- Added mixed-case variants to tests to verify case-insensitive behavior

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
