### PR TITLE
fix: detect prefixed `@keyframes` in `no-duplicate-keyframe-selectors`

### DIFF
--- a/src/rules/no-duplicate-keyframe-selectors.js
+++ b/src/rules/no-duplicate-keyframe-selectors.js
@@ -39,12 +39,12 @@ export default {
 		const seen = new Map();
 
 		return {
-			"Atrule[name=/^keyframes$/i]"() {
+			"Atrule[name=/^(-(o|moz|webkit)-)?keyframes$/i]"() {
 				insideKeyframes = true;
 				seen.clear();
 			},
 
-			"Atrule[name=/^keyframes$/i]:exit"() {
+			"Atrule[name=/^(-(o|moz|webkit)-)?keyframes$/i]:exit"() {
 				insideKeyframes = false;
 			},
 

--- a/tests/rules/no-duplicate-keyframe-selectors.test.js
+++ b/tests/rules/no-duplicate-keyframe-selectors.test.js
@@ -29,6 +29,18 @@ ruleTester.run("no-duplicate-keyframe-selectors", rule, {
             from { opacity: 0; }
             to { opacity: 1; }
         }`,
+		dedent`@-webkit-keyframes test {
+            from { opacity: 0; }
+            to { opacity: 1; }
+        }`,
+		dedent`@-moz-keyframes test {
+            0% { opacity: 0; }
+            100% { opacity: 1; }
+        }`,
+		dedent`@-o-keyframes test {
+            0% { opacity: 0; }
+            100% { opacity: 1; }
+        }`,
 		dedent`@keyframes test {
             0% { opacity: 0; }
             100% { opacity: 1; }
@@ -69,6 +81,51 @@ ruleTester.run("no-duplicate-keyframe-selectors", rule, {
 	invalid: [
 		{
 			code: dedent`@keyframes test {
+                0% { opacity: 0; }
+                0% { opacity: 1; }
+            }`,
+			errors: [
+				{
+					messageId: "duplicateKeyframeSelector",
+					line: 3,
+					column: 5,
+					endLine: 3,
+					endColumn: 7,
+				},
+			],
+		},
+		{
+			code: dedent`@-webkit-keyframes test {
+                0% { opacity: 0; }
+                0% { opacity: 1; }
+            }`,
+			errors: [
+				{
+					messageId: "duplicateKeyframeSelector",
+					line: 3,
+					column: 5,
+					endLine: 3,
+					endColumn: 7,
+				},
+			],
+		},
+		{
+			code: dedent`@-moz-keyframes test {
+                0% { opacity: 0; }
+                0% { opacity: 1; }
+            }`,
+			errors: [
+				{
+					messageId: "duplicateKeyframeSelector",
+					line: 3,
+					column: 5,
+					endLine: 3,
+					endColumn: 7,
+				},
+			],
+		},
+		{
+			code: dedent`@-o-keyframes test {
                 0% { opacity: 0; }
                 0% { opacity: 1; }
             }`,


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

### What rule do you want to change?

`no-duplicate-keyframe-selectors`

### What change do you want to make?

Generate more warnings

### How do you think the change should be implemented?

A new default behavior

### Example code

```css
@keyframes test {
      0% { opacity: 0; }
      0% { opacity: 1; }
 }
 
@-webkit-keyframes test {
      0% { opacity: 0; }
      0% { opacity: 1; }
 }
 ```

### What does the rule currently do for this code?

It only detects duplicate keyframe selectors in unprefixed `@keyframes` blocks. Prefixed blocks like `@-webkit-keyframes`, `@-moz-keyframes`, or `@-o-keyframes` are ignored, so duplicates there are not reported.

### What will the rule do after it's changed?

It will also detect duplicate keyframe selectors in vendor-prefixed `@keyframes` blocks, ensuring duplicates are reported consistently across prefixed and unprefixed animations.

#### What changes did you make? (Give an overview)

- Broadened `Atrule` matchers (enter/exit) to use: `/^(-(o|moz|webkit)-)?keyframes$/i`
- Add tests to ensure detection works for prefixed forms.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
