### PR TITLE
refactor: move option access from visitors in prefer-logical-properties

### DIFF
--- a/src/rules/prefer-logical-properties.js
+++ b/src/rules/prefer-logical-properties.js
@@ -186,6 +186,8 @@ export default {
 	},
 
 	create(context) {
+		const [{ allowProperties, allowUnits }] = context.options;
+
 		return {
 			Declaration(node) {
 				const parent = context.sourceCode.getParent(node);
@@ -193,7 +195,6 @@ export default {
 					return;
 				}
 
-				const allowProperties = context.options[0].allowProperties;
 				if (
 					propertiesReplacements.get(node.property) &&
 					!allowProperties.includes(node.property)
@@ -236,7 +237,6 @@ export default {
 				}
 			},
 			Dimension(node) {
-				const allowUnits = context.options[0].allowUnits;
 				if (
 					unitReplacements.get(node.unit) &&
 					!allowUnits.includes(node.unit)


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

To clean up the `prefer-logical-properties` rule by moving option access (`allowProperties` and `allowUnits`) out of the visitor functions.

#### What changes did you make? (Give an overview)

Moved the retrieval of `allowProperties` and `allowUnits` from inside the `Declaration` and `Dimension` visitors to the top of the `create` function.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
