### PR TITLE
test: add `exactOptionalPropertyTypes` option to type test

### DIFF
--- a/tests/types/tsconfig.json
+++ b/tests/types/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "noEmit": true,
     "rootDir": "../..",
-    "strict": true
+    "strict": true,
+    "exactOptionalPropertyTypes": true
   },
   "files": [],
   "include": [".", "../../dist"]


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

In this PR, I've added `exactOptionalPropertyTypes` option to type test.

The purpose of adding this option is to prevent the situation happened in https://github.com/eslint/markdown/issues/402 in advance.

FYI, `exactOptionalPropertyTypes` isn't included in strict mode, so it needs to be enabled manually.

https://www.typescriptlang.org/tsconfig/#exactOptionalPropertyTypes

#### What changes did you make? (Give an overview)

In this PR, I've added `exactOptionalPropertyTypes` option to type test.

#### Related Issues

Ref: https://github.com/eslint/markdown/issues/402, https://github.com/eslint/markdown/pull/524

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

N/A
