### PR TITLE
fix: handle all CSS newline types in `CSSSourceCode`

### DIFF
--- a/src/languages/css-source-code.js
+++ b/src/languages/css-source-code.js
@@ -113,7 +113,7 @@ export class CSSSourceCode extends TextSourceCodeBase {
 	 * @param {Lexer} options.lexer The lexer used to parse the source code.
 	 */
 	constructor({ text, ast, comments, lexer }) {
-		super({ text, ast });
+		super({ text, ast, lineEndingPattern: /\r\n|[\r\n\f]/u });
 		this.ast = ast;
 		this.comments = comments;
 		this.lexer = lexer;


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What did you do?

```css
a {\r/* CR */\f/* FF */\n/* LF */\r\n/* CRLF */}
```

#### What did you expect to happen?

- `CSSSourceCode.lines` returns the correct array of lines.
- `getLocFromIndex` and `getIndexFromLoc` return correct line/column positions.

#### What actually happened?

Lines containing CR or FF were not split, causing incorrect line/column calculations.

#### What is the purpose of this pull request?

According to the [CSS Syntax Module Level 3](https://www.w3.org/TR/css-syntax-3/#newline-diagram), CSS defines newline as one of:

- Line Feed (`\n`)
- Carriage Return + Line Feed (`\r\n`)
- Carriage Return (`\r`)
- Form Feed (`\f`)

`CSSSourceCode` previously only handled LF and CRLF correctly because it relied on the default `lineEndingPattern` from `TextSourceCodeBase` (`/\r?\n/`).

This PR ensures `CSSSourceCode` aligns with the CSS specification for newline handling.

#### What changes did you make? (Give an overview)

- Updated `CSSSourceCode` to pass `lineEndingPattern: /\r\n|[\r\n\f]/u` to `TextSourceCodeBase`.
- Added tests to verify correct behavior for LF, CRLF, CR, FF.

#### Related Issues

fixes #276

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
