### PR TITLE
fix: correct the return type of `applyInlineConfig`

### DIFF
--- a/src/languages/css-source-code.js
+++ b/src/languages/css-source-code.js
@@ -20,8 +20,8 @@ import { visitorKeys } from "./css-visitor-keys.js";
 //-----------------------------------------------------------------------------
 
 /**
- * @import { CssNode, CssNodePlain, Comment, Lexer, StyleSheetPlain } from "@eslint/css-tree"
- * @import { SourceRange, SourceLocation, FileProblem, DirectiveType, RulesConfig } from "@eslint/core"
+ * @import { CssNode, CssNodePlain, CssLocationRange, Comment, Lexer, StyleSheetPlain } from "@eslint/css-tree"
+ * @import { SourceRange, FileProblem, DirectiveType, RulesConfig } from "@eslint/core"
  * @import { CSSSyntaxElement } from "../types.js"
  * @import { CSSLanguageOptions } from "./css-language.js"
  */
@@ -202,13 +202,13 @@ export class CSSSourceCode extends TextSourceCodeBase {
 	/**
 	 * Returns inline rule configurations along with any problems
 	 * encountered while parsing the configurations.
-	 * @returns {{problems:Array<FileProblem>,configs:Array<{config:{rules:RulesConfig},loc:SourceLocation}>}} Information
+	 * @returns {{problems:Array<FileProblem>,configs:Array<{config:{rules:RulesConfig},loc:CssLocationRange}>}} Information
 	 *      that ESLint needs to further process the rule configurations.
 	 */
 	applyInlineConfig() {
 		/** @type {Array<FileProblem>} */
 		const problems = [];
-		/** @type {Array<{config:{rules:RulesConfig},loc:SourceLocation}>} */
+		/** @type {Array<{config:{rules:RulesConfig},loc:CssLocationRange}>} */
 		const configs = [];
 
 		this.getInlineConfigNodes().forEach(comment => {

--- a/tests/types/types.test.ts
+++ b/tests/types/types.test.ts
@@ -51,6 +51,7 @@ import type {
 	ValuePlain,
 	WhiteSpace,
 	CssNodePlain,
+	CssLocationRange,
 } from "@eslint/css-tree";
 import type { CSSRuleDefinition, CSSRuleVisitor } from "@eslint/css/types";
 
@@ -73,6 +74,19 @@ css.configs.recommended.plugins satisfies object;
 	null as AssertAllNamesIn<RecommendedRuleName, RuleName>;
 }
 
+{
+	type ApplyInlineConfigLoc = ReturnType<
+		CSSSourceCode["applyInlineConfig"]
+	>["configs"][0]["loc"];
+
+	// Check that `applyInlineConfig`'s return type includes correct `loc` structure.
+	const loc: ApplyInlineConfigLoc = {
+		source: "source",
+		start: { line: 1, column: 1, offset: 0 },
+		end: { line: 1, column: 1, offset: 0 },
+	};
+}
+
 (): CSSRuleDefinition => ({
 	create({ sourceCode }): CSSRuleVisitor {
 		sourceCode satisfies CSSSourceCode;
@@ -91,6 +105,12 @@ css.configs.recommended.plugins satisfies object;
 			sourceCode.getParent(node) satisfies CssNodePlain | undefined;
 			sourceCode.getAncestors(node) satisfies CssNodePlain[];
 			sourceCode.getText(node) satisfies string;
+			sourceCode.applyInlineConfig().configs[0].loc
+				.source satisfies CssLocationRange["source"];
+			sourceCode.applyInlineConfig().configs[0].loc.start
+				.offset satisfies CssLocationRange["start"]["offset"];
+			sourceCode.applyInlineConfig().configs[0].loc.end
+				.offset satisfies CssLocationRange["end"]["offset"];
 		}
 
 		return {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

## Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

## What is the purpose of this pull request?

### What did you do?

I expected the return type of `applyInlineConfig().configs` — specifically `loc.start` and `loc.end` — to include an `offset` property, but they don't. Also `loc.source` is missing.

### What did you expect to happen?

I expect the types of `loc.start` and `loc.end` to include an `offset` property, and for `loc.source` to be present.

### Link to minimal reproducible Example

```js
import { CSSSourceCode, CSSLanguage } from "./src/index.js";

const file = {
	body: '/* eslint css/no-important: "error" */',
	path: "test.css",
};
const language = new CSSLanguage();
const parseResult = language.parse(file);
const cssSourceCode = new CSSSourceCode({
	text: file.body,
	ast: parseResult.ast,
	comments: parseResult.comments,
});

console.log(cssSourceCode.applyInlineConfig().configs[0].loc);
```

If you run the code above, you'll see that `cssSourceCode.applyInlineConfig().configs[0].loc.start` and `cssSourceCode.applyInlineConfig().configs[0].loc.end` include an `offset` property. However, the return type doesn't reflect that `offset` property. Also, `cssSourceCode.applyInlineConfig().configs[0].loc.source` is missing from the return type.

```bash
# Output
{
  source: 'test.css',
  start: { offset: 0, line: 1, column: 1 },
  end: { offset: 38, line: 1, column: 39 }
}
```

## What changes did you make? (Give an overview)

Looking at the origin of the `loc` property returned by `applyInlineConfig`, you'll find that it directly uses the `comment.loc`.

https://github.com/eslint/css/blob/d0d58c5f9e487d85c04623b5c6961518e83caf60/src/languages/css-source-code.js#L227

The `comment.loc` property uses the `CssLocationRange` type from `@eslint/css-tree` as shown below, so technically it doesn’t match the `SourceLocation` type.

- `CssLocationRange`

```js
interface CssLocationRange {
    source: string;
    start: {
        line: number;
        column: number;
        offset: number;
    }
    end: {
        line: number;
        column: number;
        offset: number;
    }
}
```

- `SourceLocation`

```js
interface SourceLocation {
    start: {
        line: number;
        column: number;
    }
    end: {
        line: number;
        column: number;
    }
}
```

To provide a more accurate return type, I've replaced the `SourceLocation` type with the `CssLocationRange` type from `@eslint/css-tree`.

## Related Issues

Ref: https://github.com/eslint/markdown/pull/548, https://github.com/eslint/json/pull/162

<!-- include tags like "fixes #123" or "refs #123" -->

## Is there anything you'd like reviewers to focus on?

N/A