### PR TITLE
ci: resolve failure in the `release-please.yml` workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,8 +16,10 @@ jobs:
         steps:
             - uses: googleapis/release-please-action@v4
               id: release
+
             - uses: actions/checkout@v5
               if: ${{ steps.release.outputs.release_created }}
+
             - uses: actions/setup-node@v5
               with:
                   node-version: lts/*
@@ -27,6 +29,7 @@ jobs:
               # npm 11.5.1 or later is required so update to latest to be sure
             - name: Update npm
               run: npm install -g npm@latest
+              if: ${{ steps.release.outputs.release_created }}
 
             - name: Publish to npm
               run: |


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Currently, the `release-please.yml` workflow is failing for the following reason:

https://github.com/eslint/css/actions/runs/18396026583/job/52417323486

<img width="1490" height="657" alt="image" src="https://github.com/user-attachments/assets/456b3f7c-c968-4cd6-93f8-965bc50b42c3" />

The `npm install -g npm@latest` command depends on the `actions/setup-node@v5` step, so if `actions/setup-node@v5` is skipped, `npm install -g npm@latest` can't run correctly.

However, the `actions/setup-node@v5` step also depends on `steps.release.outputs.release_created`. If `steps.release.outputs.release_created` is set to `false`, then `actions/setup-node@v5` doesn't run, which causes `npm install -g npm@latest` to fail.

#### What changes did you make? (Give an overview)

To resolve the CI failure, I've added an `if: ${{ steps.release.outputs.release_created }}` check for consistency.

#### Related Issues

N/A

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

N/A