### PR TITLE
fix: disallow extra properties in rule options

### DIFF
--- a/src/rules/selector-complexity.js
+++ b/src/rules/selector-complexity.js
@@ -235,6 +235,7 @@ export default {
 						uniqueItems: true,
 					},
 				},
+				additionalProperties: false,
 			},
 		],
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This PR simply disallows extra properties in rules' schemas which currently allow them.

#### What changes did you make? (Give an overview)

#### Related Issues

This PR is similar to https://github.com/eslint/css/pull/197, but this time disallows extra properties for the recently added `selector-complexity` rule.

#### Is there anything you'd like reviewers to focus on?
