### PR TITLE
fix: enforce valid `allow*` values in `prefer-logical-properties` rule

### DIFF
--- a/docs/rules/prefer-logical-properties.md
+++ b/docs/rules/prefer-logical-properties.md
@@ -38,6 +38,30 @@ This rule accepts an option object with the following properties:
 - `allowProperties` (default: `[]`) - Specify an array of physical properties that are allowed to be used.
 - `allowUnits` (default: `[]`) - Specify an array of physical units that are allowed to be used.
 
+#### `allowProperties`
+
+Examples of **correct** code with `{ allowProperties: ["margin-left"] }`:
+
+```css
+/* eslint css/prefer-logical-properties: ["error", { allowProperties: ["margin-left"] }] */
+
+a {
+	margin-left: 10px;
+}
+```
+
+#### `allowUnits`
+
+Examples of **correct** code with `{ allowUnits: ["vw"] }`:
+
+```css
+/* eslint css/prefer-logical-properties: ["error", { allowUnits: ["vw"] }] */
+
+a {
+	margin: 10vw;
+}
+```
+
 ## When Not to Use It
 
 If you aren't concerned with the use of logical properties, then you can safely disable this rule.

--- a/src/rules/prefer-logical-properties.js
+++ b/src/rules/prefer-logical-properties.js
@@ -152,14 +152,14 @@ export default {
 					allowProperties: {
 						type: "array",
 						items: {
-							type: "string",
+							enum: Array.from(propertiesReplacements.keys()),
 						},
 						uniqueItems: true,
 					},
 					allowUnits: {
 						type: "array",
 						items: {
-							type: "string",
+							enum: Array.from(unitReplacements.keys()),
 						},
 						uniqueItems: true,
 					},

--- a/src/rules/relative-font-units.js
+++ b/src/rules/relative-font-units.js
@@ -69,8 +69,8 @@ export default {
 						type: "array",
 						items: {
 							enum: relativeFontUnits,
-							uniqueItems: true,
 						},
+						uniqueItems: true,
 					},
 				},
 				additionalProperties: false,


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This PR updates the `prefer-logical-properties` rule to enforce that the `allowProperties` and `allowUnits` options only accept valid, known CSS properties and units. Previously, invalid values were silently ignored.

#### What changes did you make? (Give an overview)

- Updated the rule schema so `allowProperties` and `allowUnits` only accept values present in `propertiesReplacements` and `unitReplacements`.
- Updated documentation with usage examples for both options.
- Corrected `uniqueItems: true` placement in `relative-font-units` schema.

#### Related Issues

Fixes #303

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
