### PR TITLE
chore: update `.gitignore` to exclude shared workflows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,4 +62,4 @@ src/build
 test.css
 
 # Automatically generated files by GitHub Actions workflow
-tools/update-readme.js
+/.shared-workflows


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

## Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

## What is the purpose of this pull request?

This PR is a follow-up to https://github.com/eslint/workflows/pull/32.

In this PR, I've updated the auto-generated location of the `update-readme` script from `tools/update-readme.js` to `/.shared-workflows`.

## What changes did you make? (Give an overview)

In this PR, I've updated the auto-generated location of the `update-readme` script from `tools/update-readme.js` to `/.shared-workflows`.

## Related Issues

Ref: https://github.com/eslint/workflows/pull/32, https://github.com/eslint/.github/pull/14#discussion_r2452382664

<!-- include tags like "fixes #123" or "refs #123" -->

## Is there anything you'd like reviewers to focus on?

N/A