### PR TITLE
test: fix CI failure caused by newly updated baseline

### DIFF
--- a/tests/rules/use-baseline.test.js
+++ b/tests/rules/use-baseline.test.js
@@ -380,18 +380,18 @@ ruleTester.run("use-baseline", rule, {
 			],
 		},
 		{
-			code: "a { color: color-mix(in hsl, hsl(200 50 80), coral 80%); }",
+			code: "a { color: light-dark(black, white); }",
 			errors: [
 				{
 					messageId: "notBaselineFunction",
 					data: {
-						function: "color-mix",
+						function: "light-dark",
 						availability: "widely",
 					},
 					line: 1,
 					column: 12,
 					endLine: 1,
-					endColumn: 56,
+					endColumn: 36,
 				},
 			],
 		},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

## Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

## What is the purpose of this pull request?

In this PR, I've fixed a CI failure caused by the newly updated baseline.

In PR #326, the `color-mix` function's baseline was changed, which caused CI to fail:

<img width="1170" height="67" alt="image" src="https://github.com/user-attachments/assets/a3495ce5-8437-4c57-bf67-0e11ff632f3b" />

https://github.com/eslint/css/actions/runs/19428945309/job/55582966958

<img width="662" height="348" alt="image" src="https://github.com/user-attachments/assets/2aea1630-0816-401a-9d2b-c53da1c34cea" />

---

Oddly, this CI failure wasn't detected in #326 itself because the test workflow didn't run in the auto-generated PR:

<img width="874" height="224" alt="image" src="https://github.com/user-attachments/assets/4a4e9445-8ba4-4f0b-a641-c48b4ad8da7a" />

## What changes did you make? (Give an overview)

In this PR, I've fixed a CI failure caused by the newly updated baseline.

I've replaced the `color-mix` function with the `light-dark` function to preserve the test case's original intent as much as possible.

## Related Issues

Ref: #326

<!-- include tags like "fixes #123" or "refs #123" -->

## Is there anything you'd like reviewers to focus on?

- https://github.com/eslint/css/pull/326
- https://github.com/eslint/css/pull/321
- https://github.com/eslint/css/pull/306
- ...

Looking through the auto-generated PRs in the history, it seems that none of them run the test workflow. They only run the following three cases:

<img width="856" height="229" alt="image" src="https://github.com/user-attachments/assets/07584b07-58b5-4f7b-be05-3c1d1223d72e" />

I think we need to update some setup so the CI workflow can run on auto-generated PRs. However, I'm not sure what the best approach is, since this may not be fixable at the code level and might require changes to the GitHub repository settings.

FYI, auto-generated `release-please` PRs, as well as repositories containing Markdown, CSS, JSON, and others, are also affected.