### PR TITLE
build: Ensure auto-created PRs run CI

### DIFF
--- a/.github/workflows/update-baseline.yml
+++ b/.github/workflows/update-baseline.yml
@@ -6,21 +6,8 @@ on:
 
 jobs:
     update-baseline:
-        env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
         runs-on: ubuntu-latest
         steps:
-            # We are using our GitHub Bot App to create the PR.
-            # This ensures that other workflows triggered by
-            # PR creation will run as expected.
-            # The GitHub Bot App is configured in the organization settings.
-            - uses: actions/create-github-app-token@v2
-              id: generate-token
-              with:
-                  app-id: ${{ vars.BOT_APP_ID }}
-                  private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
-
             - uses: actions/checkout@v5
             - name: Setup Node.js
               uses: actions/setup-node@v6
@@ -39,7 +26,7 @@ jobs:
             - name: Create Pull Request
               uses: peter-evans/create-pull-request@v7
               with:
-                  token: ${{ steps.generate-token.outputs.token }}
+                  token: ${{ secrets.WORKFLOW_PUSH_BOT_TOKEN }}
                   commit-message: "fix: update baseline data"
                   title: "fix: update baseline data"
                   branch: update-baseline-data


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

To make the update-baseline workflow run CI when opened.

#### What changes did you make? (Give an overview)

I switched the workflow to use our GitHub Bot app to create the PR instead of the default workflow user. This should trigger the other workflows to run correctly.

**Note:** `BOT_APP_PRIVATE_KEY` is only enabled for this repo. To do the same thing in other repos, we'd need to add access for those repos.

Reference:
https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
