### PR TITLE
fix: add missing `name` property to `recommended` config

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,7 @@ const plugin = {
 	rules,
 	configs: {
 		recommended: {
+			name: "@eslint/css/recommended",
 			plugins: {},
 			rules: recommendedRules,
 		},

--- a/tests/package/exports.test.js
+++ b/tests/package/exports.test.js
@@ -36,6 +36,10 @@ describe("Package exports", () => {
 		]);
 	});
 
+	it("has a `configs.recommended.name` property", () => {
+		assert.ok(exports.default.configs.recommended.name);
+	});
+
 	it("has all available rules exported in the ESLint plugin", async () => {
 		const allRules = (await fs.readdir(rulesDir))
 			.filter(name => name.endsWith(".js"))


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

## Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

## What is the purpose of this pull request?

In this PR, I added the missing `name` property to the `recommended` config.

The `@eslint/markdown` and `@eslint/js` plugins now both include a `name` property in their `recommended` or `all` configurations, but it's missing from `@eslint/css`'s `recommended` configuration.

References:

- https://github.com/eslint/markdown/blob/main/src/index.js#L93
- https://github.com/eslint/eslint/blob/main/packages/js/src/configs/eslint-recommended.js#L8
- https://github.com/eslint/eslint/blob/main/packages/js/src/configs/eslint-all.js#L8

Therefore, I added the `name` property to keep core ESLint configurations consistent.

## What changes did you make? (Give an overview)

In this PR, I added the missing `name` property to the `recommended` config.

## Related Issues

Ref: https://github.com/eslint/json/pull/189

<!-- include tags like "fixes #123" or "refs #123" -->

## Is there anything you'd like reviewers to focus on?

N/A
