### PR TITLE
chore: enable eslint for css files

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -105,7 +105,7 @@ export default defineConfig([
 		language: "json/json",
 		extends: ["json/recommended"],
 	},
-        // This CSS configuration is mainly used to validate the `test.css` file for local testing.
+	// This CSS configuration is mainly used to validate the `test.css` file for local testing.
 	{
 		name: "css/css",
 		plugins: { css },


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Enable linting CSS files, handy for `test.css` file for triaging issues & working on rules.

#### What changes did you make? (Give an overview)
Update ESLint config to lint CS files, it seems it was removed in https://github.com/eslint/css/pull/324

#### Related Issues
NA
<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
No