### PR TITLE
chore: add `.git-blame-ignore-revs`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,4 +1,4 @@
-# #335 chore: update `prettier` to fix CI
-3bd91caf9f611dd0cc62ef58169e9026db085379
 # #182 chore: fix CI error related to prettier `fmt`
 d6b2e3a52123aa49bf8047b2b92f98bd960d6234
+# #335 chore: update `prettier` to fix CI
+3bd91caf9f611dd0cc62ef58169e9026db085379


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

## Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

## What is the purpose of this pull request?

This PR was motivated by https://github.com/eslint/tsc-meetings/pull/651.

In this PR, I've added `.git-blame-ignore-revs`.

Adding a [`.git-blame-ignore-revs`](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-and-understanding-files#ignore-commits-in-the-blame-view) file prevents the squash-merged Prettier commit from appearing in GitHub's blame view.

There were some formatting-only commits in the `css` repository due to newly released Prettier versions; adding this file would help prevent noisy entries in git blame views in the future.

I followed the same format used in the `eslint` repository: https://github.com/eslint/eslint/blob/main/.git-blame-ignore-revs

## What changes did you make? (Give an overview)

In this PR, I've added `.git-blame-ignore-revs`.

## Related Issues

Ref: https://github.com/eslint/tsc-meetings/pull/651

<!-- include tags like "fixes #123" or "refs #123" -->

## Is there anything you'd like reviewers to focus on?

N/A