### PR TITLE
ci: ensure ESLint works with at least `9.15.0` and pre-releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,14 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                node: [25.x, 24.x, 22.x, 20.x, "20.19.0"] # TODO
+                eslint: [9.15.0, 9.x, ^10.0.0-rc.0]
+                node: [25.x, 24.x, 22.x, 20.x, "20.19.0"]
                 include:
                     - os: windows-latest
+                      eslint: "latest"
                       node: "lts/*"
                     - os: macOS-latest
+                      eslint: "latest"
                       node: "lts/*"
         runs-on: ${{ matrix.os }}
         steps:
@@ -42,6 +45,8 @@ jobs:
                   node-version: ${{ matrix.node }}
             - name: Install dependencies
               run: npm install
+            - name: Install ESLint@${{ matrix.eslint }}
+              run: npm install -D eslint@${{ matrix.eslint }}
             - name: Run tests
               run: npm run test
     test_types:


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

## Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

## What is the purpose of this pull request?

This PR follows up on https://github.com/eslint/json/pull/202.

In this PR, I've ensured ESLint works with at least `9.15.0`, `9.x` latest version, and in pre-releases.

I've mostly followed the same CI matrix convention used in the Markdown repository: https://github.com/eslint/markdown/blob/main/.github/workflows/ci.yml#L46-L75

### `9.15.0`

Although `9.15.0` is the minimum required ESLint version, tests didn't verify it, so I added a test to confirm compatibility with `9.15.0`:

https://github.com/eslint/css/blob/03cd8bd70a34e85365938edbdf6f3c34ecebc702/README.md?plain=1#L7
    
### `9.x`: 

Previously the version wasn't specified, so `^9.39.2` (the latest v9 release) was always installed. I added a test to confirm compatibility with the latest v9.

https://github.com/eslint/css/blob/03cd8bd70a34e85365938edbdf6f3c34ecebc702/package.json#L82
    
### `^10.0.0-rc.0`

We've gone through the breaking changes mentioned in https://github.com/eslint/css/pull/322, and as far as I know the primary focus was compatibility with ESLint v10. However, it wasn't tested against ESLint v10 locally since the local ESLint version was v9, so I've added it to ensure compatibility.

Just for reference, `eslint@^10.0.0-rc.0` includes the stable `10.0.0` release, so tests will automatically run against `10.0.0` once it is released. (We can also update the range to `10.x` later if desired.)

## What changes did you make? (Give an overview)

In this PR, I've ensured ESLint works with at least `9.15.0`, `9.x` latest version, and in pre-releases.

## Related Issues

N/A

<!-- include tags like "fixes #123" or "refs #123" -->

## Is there anything you'd like reviewers to focus on?

N/A
