### PR TITLE
fix: report invalid properties inside nested at-rules

### DIFF
--- a/src/rules/no-invalid-properties.js
+++ b/src/rules/no-invalid-properties.js
@@ -320,7 +320,7 @@ export default {
 		}
 
 		return {
-			"Rule > Block > Declaration"() {
+			"Rule > Block Declaration"() {
 				declStack.push({
 					valueParts: [],
 					functionPartsStack: [],
@@ -335,7 +335,7 @@ export default {
 				});
 			},
 
-			"Rule > Block > Declaration > Value > *:not(Function)"(node) {
+			"Rule > Block Declaration > Value > *:not(Function)"(node) {
 				const state = declStack.at(-1);
 				const text = sourceCode.getText(node).trim();
 				state.valueParts.push(text);
@@ -401,7 +401,7 @@ export default {
 				}
 			},
 
-			"Rule > Block > Declaration:exit"(node) {
+			"Rule > Block Declaration:exit"(node) {
 				const state = declStack.pop();
 				if (node.property.startsWith("--")) {
 					// store the custom property name and value to validate later

--- a/tests/rules/no-invalid-properties.test.js
+++ b/tests/rules/no-invalid-properties.test.js
@@ -1327,5 +1327,124 @@ ruleTester.run("no-invalid-properties", rule, {
 				},
 			],
 		},
+		{
+			code: ".responsive { width: red; @media (max-width: 800px) { width: red; } }",
+			errors: [
+				{
+					messageId: "invalidPropertyValue",
+					data: {
+						property: "width",
+						value: "red",
+						expected:
+							"auto | <length-percentage [0,∞]> | min-content | max-content | fit-content | fit-content( <length-percentage [0,∞]> ) | <calc-size()> | <anchor-size()> | stretch | <-non-standard-size>",
+					},
+					line: 1,
+					column: 22,
+					endLine: 1,
+					endColumn: 25,
+				},
+				{
+					messageId: "invalidPropertyValue",
+					data: {
+						property: "width",
+						value: "red",
+						expected:
+							"auto | <length-percentage [0,∞]> | min-content | max-content | fit-content | fit-content( <length-percentage [0,∞]> ) | <calc-size()> | <anchor-size()> | stretch | <-non-standard-size>",
+					},
+					line: 1,
+					column: 62,
+					endLine: 1,
+					endColumn: 65,
+				},
+			],
+		},
+		{
+			code: ".responsive { width: 10px; @media (max-width: 800px) { width: red; } }",
+			errors: [
+				{
+					messageId: "invalidPropertyValue",
+					data: {
+						property: "width",
+						value: "red",
+						expected:
+							"auto | <length-percentage [0,∞]> | min-content | max-content | fit-content | fit-content( <length-percentage [0,∞]> ) | <calc-size()> | <anchor-size()> | stretch | <-non-standard-size>",
+					},
+					line: 1,
+					column: 63,
+					endLine: 1,
+					endColumn: 66,
+				},
+			],
+		},
+		{
+			code: ".responsive { width: red; @media (max-width: 800px) { width: 10px; } }",
+			errors: [
+				{
+					messageId: "invalidPropertyValue",
+					data: {
+						property: "width",
+						value: "red",
+						expected:
+							"auto | <length-percentage [0,∞]> | min-content | max-content | fit-content | fit-content( <length-percentage [0,∞]> ) | <calc-size()> | <anchor-size()> | stretch | <-non-standard-size>",
+					},
+					line: 1,
+					column: 22,
+					endLine: 1,
+					endColumn: 25,
+				},
+			],
+		},
+		{
+			code: "@layer theme { .responsive { width: red; } }",
+			errors: [
+				{
+					messageId: "invalidPropertyValue",
+					data: {
+						property: "width",
+						value: "red",
+						expected:
+							"auto | <length-percentage [0,∞]> | min-content | max-content | fit-content | fit-content( <length-percentage [0,∞]> ) | <calc-size()> | <anchor-size()> | stretch | <-non-standard-size>",
+					},
+					line: 1,
+					column: 37,
+					endLine: 1,
+					endColumn: 40,
+				},
+			],
+		},
+		{
+			code: "a { @media screen { color: red-ish; } }",
+			errors: [
+				{
+					messageId: "invalidPropertyValue",
+					data: {
+						property: "color",
+						value: "red-ish",
+						expected: "<color>",
+					},
+					line: 1,
+					column: 28,
+					endLine: 1,
+					endColumn: 35,
+				},
+			],
+		},
+		{
+			code: "a { @media screen { @supports (display: grid) { color: red-ish; } } }",
+			errors: [
+				{
+					messageId: "invalidPropertyValue",
+					data: {
+						property: "color",
+						value: "red-ish",
+						expected: "<color>",
+					},
+					line: 1,
+					column: 56,
+					endLine: 1,
+					endColumn: 63,
+				},
+			],
+		},
 	],
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This PR fixes an issue where the `no-invalid-properties` rule failed to report invalid declarations when they were nested inside at-rules (e.g., `@media`, `@supports`) within a style rule.

#### What changes did you make? (Give an overview)

Updated `no-invalid-properties` rule selectors and added tests

#### Related Issues

Fixes #363

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
