### PR TITLE
test: re-enable nested `@layer` case in `no-invalid-at-rules`

### DIFF
--- a/tests/rules/no-invalid-at-rules.test.js
+++ b/tests/rules/no-invalid-at-rules.test.js
@@ -36,8 +36,7 @@ ruleTester.run("no-invalid-at-rules", rule, {
 		".foo { @media (max-width: 800px) { color: red; } }",
 		".foo { @media (max-width: 800px) { color: red; background: blue; font-size: 16px; } }",
 		".foo { @supports (display: grid) { display: grid; grid-template-columns: 1fr 1fr; } }",
-		// TODO: Uncomment once https://github.com/eslint/csstree/issues/106 is fixed
-		// ".foo { @layer base { color: red; } }",
+		".foo { @layer base { color: red; } }",
 		".foo { @scope (.card) { color: red; } }",
 		".foo { @container (min-width: 700px) { color: red; } }",
 		".foo { @starting-style { opacity: 0; transform: translateY(-10px); } }",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Re-enable a valid nested `@layer` test case now that it’s supported in `@eslint/css-tree` v3.6.9, to prevent regressions.

#### What changes did you make? (Give an overview)

Uncommented the nested `@layer` entry in `no-invalid-at-rules` test and removed the old TODO.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
