### PR TITLE
refactor: remove unnecessary string coercion from `data`

### DIFF
--- a/src/rules/selector-complexity.js
+++ b/src/rules/selector-complexity.js
@@ -57,7 +57,7 @@ function exceedLimitError(context, selectorLoc, maxValue, selectorType) {
 		messageId: "maxSelectors",
 		data: {
 			selector: selectorType,
-			limit: String(maxValue),
+			limit: maxValue,
 		},
 	});
 }

--- a/src/rules/use-baseline.js
+++ b/src/rules/use-baseline.js
@@ -579,7 +579,7 @@ export default {
 					data: {
 						property,
 						value: child.name,
-						availability: String(baselineAvailability.availability),
+						availability: baselineAvailability.availability,
 					},
 				});
 			}
@@ -608,7 +608,7 @@ export default {
 					messageId: "notBaselineFunction",
 					data: {
 						function: child.name,
-						availability: String(baselineAvailability.availability),
+						availability: baselineAvailability.availability,
 					},
 				});
 			}
@@ -702,9 +702,7 @@ export default {
 							messageId: "notBaselineProperty",
 							data: {
 								property,
-								availability: String(
-									baselineAvailability.availability,
-								),
+								availability: baselineAvailability.availability,
 							},
 						});
 
@@ -804,9 +802,7 @@ export default {
 							messageId: "notBaselineMediaCondition",
 							data: {
 								condition: child.name,
-								availability: String(
-									baselineAvailability.availability,
-								),
+								availability: baselineAvailability.availability,
 							},
 						});
 					}
@@ -842,9 +838,7 @@ export default {
 						messageId: "notBaselineAtRule",
 						data: {
 							atRule: node.name,
-							availability: String(
-								baselineAvailability.availability,
-							),
+							availability: baselineAvailability.availability,
 						},
 					});
 				}
@@ -893,9 +887,7 @@ export default {
 						messageId: "notBaselineSelector",
 						data: {
 							selector,
-							availability: String(
-								baselineAvailability.availability,
-							),
+							availability: baselineAvailability.availability,
 						},
 					});
 				}
@@ -919,7 +911,7 @@ export default {
 					messageId: "notBaselineSelector",
 					data: {
 						selector,
-						availability: String(baselineAvailability.availability),
+						availability: baselineAvailability.availability,
 					},
 				});
 			},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

## Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

## AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

## What is the purpose of this pull request?

This PR removes unnecessary string coercion from the `data` property.

As of `@eslint/core@1.0.1`, the `data` property's type was widened to `string | number | boolean | bigint | null | undefined` in https://github.com/eslint/rewrite/pull/327, so string coercion is no longer necessary.

The coercion was previously used to avoid TypeScript errors, so it can be removed.

## What changes did you make? (Give an overview)

This PR removes unnecessary string coercion from the `data` property.

## Related Issues

Ref: https://github.com/eslint/rewrite/pull/327

<!-- include tags like "fixes #123" or "refs #123" -->

## Is there anything you'd like reviewers to focus on?

N/A
