### PR TITLE
feat: add quotes in url in error message for `no-duplicate-imports`

### DIFF
--- a/src/rules/no-duplicate-imports.js
+++ b/src/rules/no-duplicate-imports.js
@@ -33,7 +33,7 @@ export default {
 		},
 
 		messages: {
-			duplicateImport: "Unexpected duplicate @import rule for {{url}}.",
+			duplicateImport: "Unexpected duplicate @import rule for '{{url}}'.",
 		},
 	},
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?
To update the error message of `no-duplicate-imports` rule to highlight import url.

#### What changes did you make? (Give an overview)
Added quotation marks around the url in error message.
Right now -> `Unexpected duplicate @import rule for x.css.`
After this PR -> `Unexpected duplicate @import rule for 'x.css'.`

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
