### PR TITLE
docs: fix duplicate examples

### DIFF
--- a/docs/rules/no-duplicate-keyframe-selectors.md
+++ b/docs/rules/no-duplicate-keyframe-selectors.md
@@ -54,8 +54,12 @@ Examples of **incorrect** code for this rule:
 		opacity: 0;
 	}
 
-	from {
+	to {
 		opacity: 1;
+	}
+
+	to {
+		opacity: 2;
 	}
 }
 ```

--- a/docs/rules/no-duplicate-keyframe-selectors.md
+++ b/docs/rules/no-duplicate-keyframe-selectors.md
@@ -55,11 +55,11 @@ Examples of **incorrect** code for this rule:
 	}
 
 	to {
-		opacity: 1;
+		opacity: 0.5;
 	}
 
 	to {
-		opacity: 2;
+		opacity: 1;
 	}
 }
 ```

--- a/docs/rules/no-empty-blocks.md
+++ b/docs/rules/no-empty-blocks.md
@@ -29,10 +29,10 @@ a {
 }
 
 a {
+	/* a comment */
 }
 
 .class-name {
-	/* a comment */
 }
 
 .class-name {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?
To fix duplicate code examples in rule docs for `no-empty-blocks` and `no-duplicate-keyframe-selectors` rule.

#### What changes did you make? (Give an overview)

For `no-empty-blocks` added and removed the `/* a comment */` from duplicate examples.
 
<img width="413" height="324" alt="Screenshot 2026-04-28 182058" src="https://github.com/user-attachments/assets/9462f70c-4454-4b03-8629-6dcf80c3c928" />

<img width="553" height="446" alt="Screenshot 2026-04-28 182135" src="https://github.com/user-attachments/assets/6911098a-56c2-4ad9-965e-b010dedbfad9" />

For `no-duplicate-keyframe-selectors` changed the duplicate one to

```css
@keyframes test {
       from { opacity: 0; }
       to { opacity: 1; }
       to { opacity: 2; }
 }
```


#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
