### PR TITLE
fix: update baseline data

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@arethetypeswrong/cli": "^0.18.2",
     "@eslint/json": "^1.2.0",
     "@types/node": "^20.19.0",
-    "@webref/css": "^8.5.3",
+    "@webref/css": "^8.5.4",
     "c8": "^11.0.0",
     "dedent": "^1.5.3",
     "eslint": "^10.0.0",
@@ -93,7 +93,7 @@
     "prettier": "3.8.3",
     "tailwind-csstree": "^0.3.0",
     "typescript": "^6.0.3",
-    "web-features": "^3.24.0",
+    "web-features": "^3.26.0",
     "yorkie": "^2.0.0"
   },
   "engines": {

--- a/src/data/baseline-data.js
+++ b/src/data/baseline-data.js
@@ -334,11 +334,11 @@ export const properties = new Map([
 	["overflow-y", "10:2015"],
 	["overflow-wrap", "10:2018"],
 	["overlay", "0:"],
-	["overscroll-behavior", "10:2022"],
-	["overscroll-behavior-block", "10:2022"],
-	["overscroll-behavior-inline", "10:2022"],
-	["overscroll-behavior-x", "10:2022"],
-	["overscroll-behavior-y", "10:2022"],
+	["overscroll-behavior", "0:"],
+	["overscroll-behavior-block", "0:"],
+	["overscroll-behavior-inline", "0:"],
+	["overscroll-behavior-x", "0:"],
+	["overscroll-behavior-y", "0:"],
 	["padding", "10:2015"],
 	["padding-bottom", "10:2015"],
 	["padding-left", "10:2015"],
@@ -599,7 +599,7 @@ export const functions = new Map([
 	["color-mix", "10:2023"],
 	["conic-gradient", "10:2020"],
 	["repeating-conic-gradient", "10:2020"],
-	["contrast-color", "0:"],
+	["contrast-color", "5:2026"],
 	["round", "5:2024"],
 	["superellipse", "0:"],
 	["counter", "10:2015"],
@@ -870,7 +870,13 @@ export const propertyValues = new Map([
 			["sticky", "10:2019"],
 		]),
 	],
-	["accent-color", new Map([["auto", "0:"]])],
+	[
+		"accent-color",
+		new Map([
+			["auto", "0:"],
+			["transparent", "0:"],
+		]),
+	],
 	[
 		"alignment-baseline",
 		new Map([
@@ -1385,6 +1391,7 @@ export const propertyValues = new Map([
 			["background-clip", "10:2015"],
 			["background-origin", "10:2015"],
 			["background-size", "10:2015"],
+			["currentColor", "10:2015"],
 		]),
 	],
 	[
@@ -1405,7 +1412,13 @@ export const propertyValues = new Map([
 			["text", "0:"],
 		]),
 	],
-	["background-color", new Map([["transparent", "10:2015"]])],
+	[
+		"background-color",
+		new Map([
+			["transparent", "10:2015"],
+			["currentColor", "10:2015"],
+		]),
+	],
 	[
 		"background-image",
 		new Map([
@@ -1497,7 +1510,13 @@ export const propertyValues = new Map([
 	["border-top-left-radius", new Map([["percentages", "10:2015"]])],
 	["border-top-right-radius", new Map([["percentages", "10:2015"]])],
 	["border-shape", new Map([["none", "0:"]])],
-	["border-bottom-color", new Map([["transparent", "10:2015"]])],
+	[
+		"border-bottom-color",
+		new Map([
+			["transparent", "10:2015"],
+			["currentColor", "10:2015"],
+		]),
+	],
 	[
 		"border-bottom-style",
 		new Map([
@@ -1538,10 +1557,23 @@ export const propertyValues = new Map([
 			["thick", "10:2015"],
 			["thin", "10:2015"],
 			["transparent", "10:2015"],
+			["currentColor", "10:2015"],
 		]),
 	],
-	["border-color", new Map([["transparent", "10:2015"]])],
-	["border-left-color", new Map([["transparent", "10:2015"]])],
+	[
+		"border-color",
+		new Map([
+			["transparent", "10:2015"],
+			["currentColor", "10:2015"],
+		]),
+	],
+	[
+		"border-left-color",
+		new Map([
+			["transparent", "10:2015"],
+			["currentColor", "10:2015"],
+		]),
+	],
 	[
 		"border-left-style",
 		new Map([
@@ -1582,9 +1614,16 @@ export const propertyValues = new Map([
 			["thick", "10:2015"],
 			["thin", "10:2015"],
 			["transparent", "10:2015"],
+			["currentColor", "10:2015"],
 		]),
 	],
-	["border-right-color", new Map([["transparent", "10:2015"]])],
+	[
+		"border-right-color",
+		new Map([
+			["transparent", "10:2015"],
+			["currentColor", "10:2015"],
+		]),
+	],
 	[
 		"border-right-style",
 		new Map([
@@ -1642,7 +1681,13 @@ export const propertyValues = new Map([
 			["solid", "10:2015"],
 		]),
 	],
-	["border-top-color", new Map([["transparent", "10:2015"]])],
+	[
+		"border-top-color",
+		new Map([
+			["transparent", "10:2015"],
+			["currentColor", "10:2015"],
+		]),
+	],
 	[
 		"border-top-style",
 		new Map([
@@ -1683,6 +1728,7 @@ export const propertyValues = new Map([
 			["thick", "10:2015"],
 			["thin", "10:2015"],
 			["transparent", "10:2015"],
+			["currentColor", "10:2015"],
 		]),
 	],
 	[
@@ -1710,6 +1756,7 @@ export const propertyValues = new Map([
 			["thick", "10:2015"],
 			["thin", "10:2015"],
 			["transparent", "10:2015"],
+			["currentColor", "10:2015"],
 		]),
 	],
 	[
@@ -1752,7 +1799,13 @@ export const propertyValues = new Map([
 			["view-box", "5:2023"],
 		]),
 	],
-	["color", new Map([["transparent", "10:2015"]])],
+	[
+		"color",
+		new Map([
+			["transparent", "10:2015"],
+			["currentColor", "10:2015"],
+		]),
+	],
 	[
 		"color-scheme",
 		new Map([
@@ -1897,6 +1950,13 @@ export const propertyValues = new Map([
 			["auto", "10:2020"],
 			["pixelated", "10:2021"],
 			["smooth", "0:"],
+		]),
+	],
+	[
+		"outline-color",
+		new Map([
+			["currentColor", "10:2015"],
+			["transparent", "10:2015"],
 		]),
 	],
 	[
@@ -2052,12 +2112,8 @@ export const propertyValues = new Map([
 		"font-family",
 		new Map([
 			["cursive", "10:2015"],
-			["fangsong", "10:2015"],
 			["fantasy", "10:2015"],
-			["kai", "10:2015"],
-			["khmer-mul", "10:2015"],
 			["monospace", "10:2015"],
-			["nastaliq", "10:2015"],
 			["sans-serif", "10:2015"],
 			["serif", "10:2015"],
 			["math", "5:2026"],
@@ -2696,7 +2752,6 @@ export const propertyValues = new Map([
 			["transparent", "10:2023"],
 		]),
 	],
-	["outline-color", new Map([["transparent", "10:2015"]])],
 	[
 		"outline-style",
 		new Map([
@@ -2783,41 +2838,41 @@ export const propertyValues = new Map([
 	[
 		"overscroll-behavior-block",
 		new Map([
-			["auto", "10:2022"],
-			["contain", "10:2022"],
-			["none", "10:2022"],
+			["auto", "0:"],
+			["contain", "0:"],
+			["none", "0:"],
 		]),
 	],
 	[
 		"overscroll-behavior-inline",
 		new Map([
-			["auto", "10:2022"],
-			["contain", "10:2022"],
-			["none", "10:2022"],
+			["auto", "0:"],
+			["contain", "0:"],
+			["none", "0:"],
 		]),
 	],
 	[
 		"overscroll-behavior-x",
 		new Map([
-			["auto", "10:2022"],
-			["contain", "10:2022"],
-			["none", "10:2022"],
+			["auto", "0:"],
+			["contain", "0:"],
+			["none", "0:"],
 		]),
 	],
 	[
 		"overscroll-behavior-y",
 		new Map([
-			["auto", "10:2022"],
-			["contain", "10:2022"],
-			["none", "10:2022"],
+			["auto", "0:"],
+			["contain", "0:"],
+			["none", "0:"],
 		]),
 	],
 	[
 		"overscroll-behavior",
 		new Map([
-			["auto", "10:2022"],
-			["contain", "10:2022"],
-			["none", "10:2022"],
+			["auto", "0:"],
+			["contain", "0:"],
+			["none", "0:"],
 		]),
 	],
 	[
@@ -3061,6 +3116,7 @@ export const propertyValues = new Map([
 	["marker-start", new Map([["none", "10:2017"]])],
 	["marker", new Map([["none", "10:2017"]])],
 	["shape-rendering", new Map([["auto", "10:2020"]])],
+	["stop-color", new Map([["transparent", "10:2017"]])],
 	["stroke-dasharray", new Map([["none", "10:2017"]])],
 	[
 		"stroke-linecap",

--- a/tests/rules/use-baseline.test.js
+++ b/tests/rules/use-baseline.test.js
@@ -94,7 +94,7 @@ ruleTester.run("use-baseline", rule, {
 			},
 		},
 		{
-			code: ".messages { overscroll-behavior: contain; }",
+			code: ".messages { text-align-last: center; }",
 			options: [{ available: 2022 }],
 		},
 		{


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

This PR updates the baseline data using the latest versions of `@webref/css` and `web-features`.

#### What changes did you make? (Give an overview)

- Updated `web-features` to `v3.26.0` and `@webref/css` to `v8.5.4`.
- Regenerated the baseline data to sync with the latest feature statuses.
- Replaced `overscroll-behavior` with `text-align-last` in the `use-baseline` tests. This was necessary because `overscroll-behavior` regressed from "Baseline widely available" to "Limited availability" in `web-features@3.25.0`.

#### Related Issues

Closes #439

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
