### PR TITLE
chore: pin fflate@0.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,11 @@
     "web-features": "^3.27.0",
     "yorkie": "^2.0.0"
   },
+  "overrides": {
+    "@arethetypeswrong/core": {
+      "fflate": "0.8.2"
+    }
+  },
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24"
   }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

Similar to https://github.com/eslint/eslint/pull/20877.

This PR fixes a failure when running `lint:types` script. An example in CI:

https://github.com/eslint/css/actions/runs/25976631692/job/76357740759

#### What changes did you make? (Give an overview)

As explained in https://github.com/arethetypeswrong/arethetypeswrong.github.io/issues/258, the problem is caused by `@arethetypeswrong/core` relying on an internal behavior of `fflate`, which has changed in recently released v0.8.3.

This PR adds an overrides to `package.json` to pin `fflate` to `v0.8.2` for `@arethetypeswrong/core`.

#### Related Issues

https://github.com/eslint/eslint/pull/20877

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
