### PR TITLE
ci: declare workflow-level contents: read on 4 workflows

### DIFF
--- a/.github/workflows/ci-bun.yml
+++ b/.github/workflows/ci-bun.yml
@@ -9,6 +9,9 @@ on:
         branches:
             - main
 
+permissions:
+    contents: read
+
 jobs:
     ci-bun:
         uses: eslint/workflows/.github/workflows/ci-bun.yml@main

--- a/.github/workflows/ci-package-manager.yml
+++ b/.github/workflows/ci-package-manager.yml
@@ -9,6 +9,9 @@ on:
         branches:
             - main
 
+permissions:
+    contents: read
+
 jobs:
     ci-package-manager:
         uses: eslint/workflows/.github/workflows/ci-package-manager.yml@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     pull_request:
         branches:
             - main
+permissions:
+    contents: read
+
 jobs:
     verify_files:
         name: Verify Files

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -6,6 +6,9 @@ on:
 
     workflow_dispatch:
 
+permissions:
+    contents: read
+
 jobs:
     update-readme:
         uses: eslint/workflows/.github/workflows/update-readme.yml@main


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on four workflows: `ci-bun`, `ci-package-manager`, `ci`, `update-readme`. None of them make GitHub API writes beyond checkout.

Reopening the change from #450 - that one auto-closed when a recovery force-push severed the previous PR HEAD from the new branch history. The diff here is the same intent (4 files, +12 lines) on top of current `main`.

Post-CVE-2025-30066 (`tj-actions/changed-files`) hardening pattern. Indent matches the existing 4-space YAML style in this repo. YAML validated locally.