### PR TITLE
test: add data property to `relative-font-units` tests

### DIFF
--- a/tests/rules/relative-font-units.test.js
+++ b/tests/rules/relative-font-units.test.js
@@ -335,6 +335,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -343,6 +344,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -356,6 +358,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "em" },
 				},
 			],
 		},
@@ -369,6 +372,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "em" },
 				},
 			],
 		},
@@ -382,6 +386,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "%" },
 				},
 			],
 		},
@@ -395,6 +400,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "cap" },
 				},
 			],
 		},
@@ -408,6 +414,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "ch" },
 				},
 			],
 		},
@@ -421,6 +428,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "ex" },
 				},
 			],
 		},
@@ -434,6 +442,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "ic" },
 				},
 			],
 		},
@@ -447,6 +456,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "em" },
 				},
 			],
 		},
@@ -460,6 +470,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "lh" },
 				},
 			],
 		},
@@ -473,6 +484,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rcap" },
 				},
 			],
 		},
@@ -486,6 +498,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rch" },
 				},
 			],
 		},
@@ -499,6 +512,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rex" },
 				},
 			],
 		},
@@ -512,6 +526,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "ric" },
 				},
 			],
 		},
@@ -525,6 +540,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rlh" },
 				},
 			],
 		},
@@ -545,6 +561,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "em" },
 				},
 			],
 		},
@@ -563,37 +580,73 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "em" },
 				},
 			],
 		},
 		{
 			code: "a { font-size: 1PX; }",
-			errors: [{ messageId: "allowedFontUnits" }],
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
+				},
+			],
 		},
 		{
 			code: "a { font-size: 1IN; }",
-			errors: [{ messageId: "allowedFontUnits" }],
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
+				},
+			],
 		},
 		{
 			code: "a { font-size: 1CM; }",
-			errors: [{ messageId: "allowedFontUnits" }],
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
+				},
+			],
 		},
 		{
 			code: "a { font-size: 1MM; }",
-			errors: [{ messageId: "allowedFontUnits" }],
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
+				},
+			],
 		},
 		{
 			code: "a { font-size: 1PT; }",
-			errors: [{ messageId: "allowedFontUnits" }],
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
+				},
+			],
 		},
 		{
 			code: "a { font-size: 1PC; }",
-			errors: [{ messageId: "allowedFontUnits" }],
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
+				},
+			],
 		},
 		{
 			code: "a { font-size: 1EM; }",
 			options: [{ allowUnits: ["rem"] }],
-			errors: [{ messageId: "allowedFontUnits" }],
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
+				},
+			],
 		},
 		{
 			code: "a { font: 2EM Arial, sans-serif; }",
@@ -605,6 +658,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -613,6 +667,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -621,6 +676,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -629,6 +685,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -637,6 +694,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -645,6 +703,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -653,6 +712,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -661,6 +721,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -669,6 +730,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -677,6 +739,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -685,6 +748,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -693,6 +757,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -701,6 +766,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -709,6 +775,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -717,6 +784,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -725,6 +793,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -733,6 +802,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -741,6 +811,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -758,6 +829,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "em" },
 				},
 			],
 		},
@@ -775,6 +847,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "em" },
 				},
 			],
 		},
@@ -792,6 +865,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "%" },
 				},
 			],
 		},
@@ -809,6 +883,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "%" },
 				},
 			],
 		},
@@ -826,6 +901,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "%, em" },
 				},
 			],
 		},
@@ -846,6 +922,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem, rex" },
 				},
 			],
 		},
@@ -867,6 +944,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem, rex, %" },
 				},
 			],
 		},
@@ -884,6 +962,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "lh, rex, %" },
 				},
 			],
 		},
@@ -896,6 +975,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -908,6 +988,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -920,6 +1001,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -933,6 +1015,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -941,6 +1024,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -949,6 +1033,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -957,6 +1042,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -965,6 +1051,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -973,6 +1060,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -981,6 +1069,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -989,6 +1078,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -997,6 +1087,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -1005,6 +1096,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -1013,6 +1105,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -1021,6 +1114,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -1029,6 +1123,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -1037,6 +1132,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -1045,6 +1141,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -1053,6 +1150,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -1061,6 +1159,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -1069,6 +1168,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -1077,6 +1177,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -1085,6 +1186,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -1093,6 +1195,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -1101,6 +1204,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -1109,6 +1213,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -1117,6 +1222,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -1125,6 +1231,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -1133,6 +1240,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -1141,6 +1249,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -1149,6 +1258,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -1157,6 +1267,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -1165,6 +1276,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -1173,6 +1285,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -1181,6 +1294,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -1189,6 +1303,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -1197,6 +1312,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -1205,6 +1321,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -1213,6 +1330,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},
@@ -1221,6 +1339,7 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},

--- a/tests/rules/relative-font-units.test.js
+++ b/tests/rules/relative-font-units.test.js
@@ -651,7 +651,12 @@ ruleTester.run("relative-font-units", rule, {
 		{
 			code: "a { font: 2EM Arial, sans-serif; }",
 			options: [{ allowUnits: ["rem"] }],
-			errors: [{ messageId: "allowedFontUnits" }],
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
+				},
+			],
 		},
 		{
 			code: "a { font-size: xx-small; }",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?
To add the `data` property to the `relative-font-units` tests to ensure we are passing the correct data to the message.

#### What changes did you make? (Give an overview)
Added the `data` property to the invalid test for `relative-font-units`.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
