### PR TITLE
test: add data property to `no-duplicate-keyframe-selectors` tests

### DIFF
--- a/tests/rules/no-duplicate-keyframe-selectors.test.js
+++ b/tests/rules/no-duplicate-keyframe-selectors.test.js
@@ -87,6 +87,7 @@ ruleTester.run("no-duplicate-keyframe-selectors", rule, {
 			errors: [
 				{
 					messageId: "duplicateKeyframeSelector",
+					data: { selector: "0%" },
 					line: 3,
 					column: 5,
 					endLine: 3,
@@ -102,6 +103,7 @@ ruleTester.run("no-duplicate-keyframe-selectors", rule, {
 			errors: [
 				{
 					messageId: "duplicateKeyframeSelector",
+					data: { selector: "0%" },
 					line: 3,
 					column: 5,
 					endLine: 3,
@@ -117,6 +119,7 @@ ruleTester.run("no-duplicate-keyframe-selectors", rule, {
 			errors: [
 				{
 					messageId: "duplicateKeyframeSelector",
+					data: { selector: "0%" },
 					line: 3,
 					column: 5,
 					endLine: 3,
@@ -132,6 +135,7 @@ ruleTester.run("no-duplicate-keyframe-selectors", rule, {
 			errors: [
 				{
 					messageId: "duplicateKeyframeSelector",
+					data: { selector: "0%" },
 					line: 3,
 					column: 5,
 					endLine: 3,
@@ -149,6 +153,7 @@ ruleTester.run("no-duplicate-keyframe-selectors", rule, {
 			errors: [
 				{
 					messageId: "duplicateKeyframeSelector",
+					data: { selector: "10.5%" },
 					line: 4,
 					column: 5,
 					endLine: 4,
@@ -164,6 +169,7 @@ ruleTester.run("no-duplicate-keyframe-selectors", rule, {
 			errors: [
 				{
 					messageId: "duplicateKeyframeSelector",
+					data: { selector: "from" },
 					line: 3,
 					column: 5,
 					endLine: 3,
@@ -179,6 +185,7 @@ ruleTester.run("no-duplicate-keyframe-selectors", rule, {
 			errors: [
 				{
 					messageId: "duplicateKeyframeSelector",
+					data: { selector: "from" },
 					line: 3,
 					column: 5,
 					endLine: 3,
@@ -194,6 +201,7 @@ ruleTester.run("no-duplicate-keyframe-selectors", rule, {
 			errors: [
 				{
 					messageId: "duplicateKeyframeSelector",
+					data: { selector: "from" },
 					line: 3,
 					column: 5,
 					endLine: 3,
@@ -210,6 +218,7 @@ ruleTester.run("no-duplicate-keyframe-selectors", rule, {
 			errors: [
 				{
 					messageId: "duplicateKeyframeSelector",
+					data: { selector: "to" },
 					line: 4,
 					column: 5,
 					endLine: 4,
@@ -226,6 +235,7 @@ ruleTester.run("no-duplicate-keyframe-selectors", rule, {
 			errors: [
 				{
 					messageId: "duplicateKeyframeSelector",
+					data: { selector: "to" },
 					line: 4,
 					column: 5,
 					endLine: 4,
@@ -243,6 +253,7 @@ ruleTester.run("no-duplicate-keyframe-selectors", rule, {
 			errors: [
 				{
 					messageId: "duplicateKeyframeSelector",
+					data: { selector: "50%" },
 					line: 4,
 					column: 5,
 					endLine: 4,
@@ -276,6 +287,7 @@ ruleTester.run("no-duplicate-keyframe-selectors", rule, {
 			errors: [
 				{
 					messageId: "duplicateKeyframeSelector",
+					data: { selector: "0%" },
 					line: 6,
 					column: 5,
 					endLine: 6,
@@ -283,6 +295,7 @@ ruleTester.run("no-duplicate-keyframe-selectors", rule, {
 				},
 				{
 					messageId: "duplicateKeyframeSelector",
+					data: { selector: "50%" },
 					line: 14,
 					column: 5,
 					endLine: 14,
@@ -290,6 +303,7 @@ ruleTester.run("no-duplicate-keyframe-selectors", rule, {
 				},
 				{
 					messageId: "duplicateKeyframeSelector",
+					data: { selector: "50%" },
 					line: 18,
 					column: 5,
 					endLine: 18,
@@ -308,6 +322,7 @@ ruleTester.run("no-duplicate-keyframe-selectors", rule, {
 			errors: [
 				{
 					messageId: "duplicateKeyframeSelector",
+					data: { selector: "0%" },
 					line: 5,
 					column: 5,
 					endLine: 5,
@@ -323,6 +338,7 @@ ruleTester.run("no-duplicate-keyframe-selectors", rule, {
 			errors: [
 				{
 					messageId: "duplicateKeyframeSelector",
+					data: { selector: "0%" },
 					line: 3,
 					column: 5,
 					endLine: 3,
@@ -356,6 +372,7 @@ ruleTester.run("no-duplicate-keyframe-selectors", rule, {
 			errors: [
 				{
 					messageId: "duplicateKeyframeSelector",
+					data: { selector: "0%" },
 					line: 6,
 					column: 5,
 					endLine: 6,
@@ -363,6 +380,7 @@ ruleTester.run("no-duplicate-keyframe-selectors", rule, {
 				},
 				{
 					messageId: "duplicateKeyframeSelector",
+					data: { selector: "50%" },
 					line: 14,
 					column: 5,
 					endLine: 14,
@@ -370,6 +388,7 @@ ruleTester.run("no-duplicate-keyframe-selectors", rule, {
 				},
 				{
 					messageId: "duplicateKeyframeSelector",
+					data: { selector: "50%" },
 					line: 18,
 					column: 5,
 					endLine: 18,


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?
To add the data property to the `no-duplicate-keyframe-selectors` tests to ensure we are passing the correct data to the message.

#### What changes did you make? (Give an overview)
Added the data property to the invalid test for `no-duplicate-keyframe-selectors`.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
