### PR TITLE
fix: reporting font-size unit with percentage in line-height

### DIFF
--- a/src/rules/relative-font-units.js
+++ b/src/rules/relative-font-units.js
@@ -139,8 +139,22 @@ export default {
 							child => child.type === "Identifier",
 						);
 						const percentageNode = value.children.find(
-							child => child.type === "Percentage",
+							(child, index) => {
+								const isPercentage =
+									child.type === "Percentage";
+								const previousNode = value.children[index - 1];
+
+								const previousNodeIsSlashOperator =
+									previousNode &&
+									previousNode.type === "Operator" &&
+									previousNode.value === "/";
+
+								return (
+									isPercentage && !previousNodeIsSlashOperator
+								);
+							},
 						);
+
 						let location;
 						let shouldReport = false;
 

--- a/tests/rules/relative-font-units.test.js
+++ b/tests/rules/relative-font-units.test.js
@@ -50,6 +50,7 @@ ruleTester.run("relative-font-units", rule, {
 		"a { font: revert-layer Arial, sans-serif; }",
 		"a { font-size: unset; }",
 		"a { font: unset Arial, sans-serif; }",
+		"a { font: 1rem/120% Arial, sans-serif; }",
 		{
 			code: "a { font-size: 1em; }",
 			options: [
@@ -842,6 +843,24 @@ ruleTester.run("relative-font-units", rule, {
 			code: dedent`
                 a {
                     font: 20% Arial, sans-serif;
+                }
+            `,
+			options: [
+				{
+					allowUnits: ["em"],
+				},
+			],
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "em" },
+				},
+			],
+		},
+		{
+			code: dedent`
+                a {
+                    font: 1rem/120% Arial, sans-serif;
                 }
             `,
 			options: [


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?
In `relative-font-units` this PR fixes the reporting of font size with the correct unit when line-height is used with a percentage, such as:

```css
/* eslint css/relative-font-units: ["error", { allowUnits: ["rem"] }] */

a {
    font: 1rem/120% Arial, sans-serif;
 }
```
Right now, the rule is reporting this.
#### What changes did you make? (Give an overview)
Added a condition to check whether the percentage is used with font-size or line-height.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
