### PR TITLE
fix: check for preludes in `@import`

### DIFF
--- a/src/rules/no-duplicate-imports.js
+++ b/src/rules/no-duplicate-imports.js
@@ -45,10 +45,10 @@ function getImportEnd(text, end) {
 function getImportModifiers(importNode, sourceCode) {
 	const importModifiers = [];
 
-	const importHasModifiers = importNode.prelude.children.length > 1;
+	const importHasModifiers = importNode.prelude?.children.length > 1;
 
 	if (importHasModifiers) {
-		importNode.prelude.children.slice(1).forEach(modifier => {
+		importNode.prelude?.children.slice(1).forEach(modifier => {
 			const modifierText = sourceCode.getText(modifier).trim();
 			importModifiers.push(modifierText);
 		});
@@ -111,22 +111,22 @@ export default {
 
 		return {
 			"Atrule[name=/^import$/i]"(node) {
-				const url = node.prelude.children[0].value;
+				const url = node.prelude?.children[0].value;
 				const hasImport = imports.some(
-					importNode => importNode.prelude.children[0].value === url,
+					importNode => importNode.prelude?.children[0].value === url,
 				);
 
 				if (hasImport) {
 					const firstImportNode = imports.find(
 						importNode =>
-							importNode.prelude.children[0].value === url,
+							importNode.prelude?.children[0].value === url,
 					);
 					const [firstImportStart, firstImportEnd] =
 						sourceCode.getRange(firstImportNode);
 
 					const firstImportHasModifiers =
-						firstImportNode.prelude.children.length > 1;
-					const nodeHasModifiers = node.prelude.children.length > 1;
+						firstImportNode.prelude?.children.length > 1;
+					const nodeHasModifiers = node.prelude?.children.length > 1;
 
 					const [start, end] = sourceCode.getRange(node);
 					const text = sourceCode.text;

--- a/src/rules/use-layers.js
+++ b/src/rules/use-layers.js
@@ -77,7 +77,7 @@ export default {
 		return {
 			"Atrule[name=/^import$/i]"(node) {
 				// layer, if present, must always be the second child of the prelude
-				const secondChild = node.prelude.children[1];
+				const secondChild = node.prelude?.children[1];
 				const layerNode =
 					secondChild?.name === "layer" ? secondChild : null;
 

--- a/tests/rules/no-duplicate-imports.test.js
+++ b/tests/rules/no-duplicate-imports.test.js
@@ -30,6 +30,7 @@ ruleTester.run("no-duplicate-imports", rule, {
 		"@IMPORT url('x.css');",
 		"@imPort url('x.css'); @IMport url('y.css');",
 		"@IMPORT 'x.css'; @import url('y.css'); @IMport 'z.css';",
+		"@import url('x.css'); @import;",
 	],
 	invalid: [
 		{

--- a/tests/rules/use-layers.test.js
+++ b/tests/rules/use-layers.test.js
@@ -227,6 +227,18 @@ ruleTester.run("use-layers", rule, {
 			],
 		},
 		{
+			code: "@import;",
+			errors: [
+				{
+					messageId: "missingImportLayer",
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 9,
+				},
+			],
+		},
+		{
 			code: "@IMPORT 'foo.css';",
 			errors: [
 				{


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?
To avoid any errors when there are no preludes in CSS `@import` like `@import;`.

#### What changes did you make? (Give an overview)
Added the optional chaining operator to the prelude property of the import atrule node.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
