### PR TITLE
fix: false negative when font used as identifier

### DIFF
--- a/src/rules/relative-font-units.js
+++ b/src/rules/relative-font-units.js
@@ -136,7 +136,11 @@ export default {
 							child => child.type === "Dimension",
 						);
 						const identifierNode = value.children.find(
-							child => child.type === "Identifier",
+							child =>
+								child.type === "Identifier" &&
+								disallowedFontSizeKeywords.has(
+									child.name.toLowerCase(),
+								),
 						);
 						const percentageNode = value.children.find(
 							(child, index) => {
@@ -166,11 +170,7 @@ export default {
 								loc: percentageNode?.loc,
 							},
 							{
-								check:
-									identifierNode &&
-									disallowedFontSizeKeywords.has(
-										identifierNode.name.toLowerCase(),
-									),
+								check: identifierNode,
 								loc: identifierNode?.loc,
 							},
 							{

--- a/tests/rules/relative-font-units.test.js
+++ b/tests/rules/relative-font-units.test.js
@@ -51,6 +51,7 @@ ruleTester.run("relative-font-units", rule, {
 		"a { font-size: unset; }",
 		"a { font: unset Arial, sans-serif; }",
 		"a { font: 1rem/120% Arial, sans-serif; }",
+		"a { font: italic smaller Arial, sans-serif; }",
 		{
 			code: "a { font-size: 1em; }",
 			options: [
@@ -1252,6 +1253,15 @@ ruleTester.run("relative-font-units", rule, {
 		},
 		{
 			code: "a { font: Small Arial, sans-serif; }",
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+					data: { allowedFontUnits: "rem" },
+				},
+			],
+		},
+		{
+			code: "a { font: italic small Arial, sans-serif; }",
 			errors: [
 				{
 					messageId: "allowedFontUnits",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?
To fix the false negative in `relative-font-units` when an identifier is used to set font size in `font` property, it fails to report the identifier font if there is another identifier used before it like `italic` or `bold` etc.

```css
"a { font: italic small Arial, sans-serif; }",
```

Right now, the rule is not reporting this.

#### What changes did you make? (Give an overview)
Fixed the logic to find the disallowed identifier font size in `font`.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
