### PR TITLE
fix: type compatibility issue between CSS v1 and ESLint v9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,6 @@ jobs:
     test_types:
         name: Test Types
         strategy:
-            fail-fast: false # TODO: Remove
             matrix:
                 eslint: [9.15.0, 9.x, 10.x]
         runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
                   node-version: "lts/*"
             - name: Install dependencies
               run: npm install
-            - name: Install ESLint@${{ matrix.eslint }}
+            - name: Install ESLint v${{ matrix.eslint }}
               run: npm install -D eslint@${{ matrix.eslint }}
             - name: Check Types
               run: npm run test:types

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,10 @@ jobs:
               run: npm run test
     test_types:
         name: Test Types
+        strategy:
+            fail-fast: false # TODO: Remove
+            matrix:
+                eslint: [9.15.0, 9.x, 10.x]
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
@@ -65,6 +69,8 @@ jobs:
                   node-version: "lts/*"
             - name: Install dependencies
               run: npm install
+            - name: Install ESLint@${{ matrix.eslint }}
+              run: npm install -D eslint@${{ matrix.eslint }}
             - name: Check Types
               run: npm run test:types
             - name: Check Types (TypeScript 5.3)

--- a/src/rules/font-family-fallbacks.js
+++ b/src/rules/font-family-fallbacks.js
@@ -111,10 +111,7 @@ function reportFontWithoutFallbacksInFontProperty(
 // Rule Definition
 //-----------------------------------------------------------------------------
 
-/**
- * @type {FontFamilyFallbacksRuleDefinition}
- */
-export default {
+export default /** @satisfies {FontFamilyFallbacksRuleDefinition} */ ({
 	meta: {
 		type: "suggestion",
 
@@ -475,4 +472,4 @@ export default {
 			},
 		};
 	},
-};
+});

--- a/src/rules/no-duplicate-imports.js
+++ b/src/rules/no-duplicate-imports.js
@@ -80,10 +80,7 @@ function getFixForImport(fixer, text, start, end, hasModifiers) {
 // Rule
 //-----------------------------------------------------------------------------
 
-/**
- * @type {NoDuplicateImportsRuleDefinition}
- */
-export default {
+export default /** @satisfies {NoDuplicateImportsRuleDefinition} */ ({
 	meta: {
 		type: "problem",
 
@@ -220,4 +217,4 @@ export default {
 			},
 		};
 	},
-};
+});

--- a/src/rules/no-duplicate-keyframe-selectors.js
+++ b/src/rules/no-duplicate-keyframe-selectors.js
@@ -17,8 +17,7 @@
 // Rule Definition
 //-----------------------------------------------------------------------------
 
-/** @type {DuplicateKeyframeSelectorRuleDefinition} */
-export default {
+export default /** @satisfies {DuplicateKeyframeSelectorRuleDefinition} */ ({
 	meta: {
 		type: "problem",
 
@@ -78,4 +77,4 @@ export default {
 			},
 		};
 	},
-};
+});

--- a/src/rules/no-empty-blocks.js
+++ b/src/rules/no-empty-blocks.js
@@ -17,8 +17,7 @@
 // Rule Definition
 //-----------------------------------------------------------------------------
 
-/** @type {NoEmptyBlocksRuleDefinition} */
-export default {
+export default /** @satisfies {NoEmptyBlocksRuleDefinition} */ ({
 	meta: {
 		type: "problem",
 
@@ -45,4 +44,4 @@ export default {
 			},
 		};
 	},
-};
+});

--- a/src/rules/no-important.js
+++ b/src/rules/no-important.js
@@ -26,8 +26,7 @@ const trailingWhitespacePattern = /\s*$/u;
 // Rule Definition
 //-----------------------------------------------------------------------------
 
-/** @type {NoImportantRuleDefinition} */
-export default {
+export default /** @satisfies {NoImportantRuleDefinition} */ ({
 	meta: {
 		type: "problem",
 
@@ -95,4 +94,4 @@ export default {
 			},
 		};
 	},
-};
+});

--- a/src/rules/no-invalid-at-rule-placement.js
+++ b/src/rules/no-invalid-at-rule-placement.js
@@ -17,8 +17,7 @@
 // Rule Definition
 //-----------------------------------------------------------------------------
 
-/** @type {NoInvalidAtRulePlacementRuleDefinition} */
-export default {
+export default /** @satisfies {NoInvalidAtRulePlacementRuleDefinition} */ ({
 	meta: {
 		type: "problem",
 
@@ -102,4 +101,4 @@ export default {
 			},
 		};
 	},
-};
+});

--- a/src/rules/no-invalid-at-rules.js
+++ b/src/rules/no-invalid-at-rules.js
@@ -74,8 +74,7 @@ function extractMetaDataFromError(error) {
 // Rule Definition
 //-----------------------------------------------------------------------------
 
-/** @type {NoInvalidAtRulesRuleDefinition} */
-export default {
+export default /** @satisfies {NoInvalidAtRulesRuleDefinition} */ ({
 	meta: {
 		type: "problem",
 
@@ -287,4 +286,4 @@ export default {
 			},
 		};
 	},
-};
+});

--- a/src/rules/no-invalid-named-grid-areas.js
+++ b/src/rules/no-invalid-named-grid-areas.js
@@ -79,8 +79,7 @@ const validProps = new Set(["grid-template-areas", "grid-template", "grid"]);
 // Rule Definition
 //-----------------------------------------------------------------------------
 
-/** @type {NoInvalidNamedGridAreasRuleDefinition} */
-export default {
+export default /** @satisfies {NoInvalidNamedGridAreasRuleDefinition} */ ({
 	meta: {
 		type: "problem",
 
@@ -175,4 +174,4 @@ export default {
 			},
 		};
 	},
-};
+});

--- a/src/rules/no-invalid-properties.js
+++ b/src/rules/no-invalid-properties.js
@@ -86,8 +86,7 @@ function getVarFallbackList(value) {
 // Rule Definition
 //-----------------------------------------------------------------------------
 
-/** @type {NoInvalidPropertiesRuleDefinition} */
-export default {
+export default /** @satisfies {NoInvalidPropertiesRuleDefinition} */ ({
 	meta: {
 		type: "problem",
 
@@ -490,4 +489,4 @@ export default {
 			},
 		};
 	},
-};
+});

--- a/src/rules/no-unmatchable-selectors.js
+++ b/src/rules/no-unmatchable-selectors.js
@@ -17,8 +17,7 @@
 // Rule Definition
 //-----------------------------------------------------------------------------
 
-/** @type {NoUnmatchableSelectorsRuleDefinition} */
-export default {
+export default /** @satisfies {NoUnmatchableSelectorsRuleDefinition} */ ({
 	meta: {
 		type: "problem",
 
@@ -58,4 +57,4 @@ export default {
 			},
 		};
 	},
-};
+});

--- a/src/rules/prefer-logical-properties.js
+++ b/src/rules/prefer-logical-properties.js
@@ -133,8 +133,7 @@ const unitReplacements = new Map([
 // Rule Definition
 //-----------------------------------------------------------------------------
 
-/** @type {PreferLogicalPropertiesRuleDefinition} */
-export default {
+export default /** @satisfies {PreferLogicalPropertiesRuleDefinition} */ ({
 	meta: {
 		type: "problem",
 
@@ -253,4 +252,4 @@ export default {
 			},
 		};
 	},
-};
+});

--- a/src/rules/relative-font-units.js
+++ b/src/rules/relative-font-units.js
@@ -50,8 +50,7 @@ const disallowedFontSizeKeywords = new Set([
 // Rule Definition
 //-----------------------------------------------------------------------------
 
-/** @type {RelativeFontUnitsRuleDefinition} */
-export default {
+export default /** @satisfies {RelativeFontUnitsRuleDefinition} */ ({
 	meta: {
 		type: "suggestion",
 
@@ -205,4 +204,4 @@ export default {
 			},
 		};
 	},
-};
+});

--- a/src/rules/selector-complexity.js
+++ b/src/rules/selector-complexity.js
@@ -152,8 +152,7 @@ function getDisallowedCombinatorsLocation(
 // Rule Definition
 //-----------------------------------------------------------------------------
 
-/** @type {SelectorComplexityRuleDefinition} */
-export default {
+export default /** @satisfies {SelectorComplexityRuleDefinition} */ ({
 	meta: {
 		type: "problem",
 
@@ -497,4 +496,4 @@ export default {
 			},
 		};
 	},
-};
+});

--- a/src/rules/use-baseline.js
+++ b/src/rules/use-baseline.js
@@ -483,8 +483,7 @@ class BaselineAvailability {
 // Rule Definition
 //-----------------------------------------------------------------------------
 
-/** @type {UseBaselineRuleDefinition} */
-export default {
+export default /** @satisfies {UseBaselineRuleDefinition} */ ({
 	meta: {
 		type: "problem",
 
@@ -1048,4 +1047,4 @@ export default {
 			},
 		};
 	},
-};
+});

--- a/src/rules/use-layers.js
+++ b/src/rules/use-layers.js
@@ -22,8 +22,7 @@
 // Rule Definition
 //-----------------------------------------------------------------------------
 
-/** @type {UseLayersRuleDefinition} */
-export default {
+export default /** @satisfies {UseLayersRuleDefinition} */ ({
 	meta: {
 		type: "problem",
 
@@ -167,4 +166,4 @@ export default {
 			},
 		};
 	},
-};
+});

--- a/tests/types/types.test.ts
+++ b/tests/types/types.test.ts
@@ -61,7 +61,7 @@ import type {
 
 css satisfies Plugin;
 // This type check verifies that the plugin is compatible with ESLint v9.15.0, v9.x, and v10.x.
-// See: https://github.com/eslint/json/pull/248
+// See: https://github.com/eslint/css/pull/473
 css satisfies ESLint.Plugin;
 css.meta.name satisfies string;
 css.meta.version satisfies string;

--- a/tests/types/types.test.ts
+++ b/tests/types/types.test.ts
@@ -5,6 +5,7 @@ import type {
 	CSSSourceCode,
 } from "@eslint/css";
 import type { Plugin, SourceLocation, SourceRange } from "@eslint/core";
+import type { ESLint } from "eslint";
 import type {
 	AnPlusB,
 	AtrulePlain,
@@ -59,11 +60,17 @@ import type {
 } from "@eslint/css-tree";
 
 css satisfies Plugin;
+// This type check verifies that the plugin is compatible with ESLint v9.15.0, v9.x, and v10.x.
+// See: https://github.com/eslint/json/pull/248
+css satisfies ESLint.Plugin;
 css.meta.name satisfies string;
 css.meta.version satisfies string;
 
 // Check that these languages are defined:
 css.languages.css satisfies object;
+
+declare const ruleName: keyof typeof css.rules;
+css.rules[ruleName] satisfies CSSRuleDefinition;
 
 // Check that `plugins` in the recommended config is defined:
 css.configs.recommended.plugins satisfies object;

--- a/tools/build-rules.js
+++ b/tools/build-rules.js
@@ -21,7 +21,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 
 const thisDir = path.dirname(fileURLToPath(import.meta.url));
 const rulesPath = path.resolve(thisDir, "../src/rules");
-const rules = fs.readdirSync(rulesPath);
+const rules = fs.readdirSync(rulesPath).sort();
 const recommended = [];
 
 for (const ruleId of rules) {
@@ -52,7 +52,12 @@ const rulesOutput = `
 ${rules.map((id, index) => `import rule${index} from "../rules/${id}";`).join("\n")}
 
 export default {
-    ${rules.map((id, index) => `"${id.slice(0, -3)}": rule${index},`).join("\n    ")}
+    ${rules
+		.map(
+			(id, index) =>
+				`"${id.slice(0, -3)}": /** @type {{meta: typeof rule${index}.meta; create: (context: unknown) => any}} */ (rule${index}),`,
+		)
+		.join("\n    ")}
 };
 `.trim();
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

## Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

## AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

## What is the purpose of this pull request?

This PR fixes an issue where CSS v1 and ESLint v9 are not type-compatible, as mentioned in eslint/json#213.

## What changes did you make? (Give an overview)

This PR follows the same strategy determined in https://github.com/eslint/markdown/pull/648. That said, a few parts differ from the Markdown implementation, as follows:

1. For CSS, the type compatibility range is 9.15.0 or above, not 9.39.0. This is because the [Markdown plugin has a `processor`](https://github.com/eslint/markdown/blob/main/src/index.js#L100), and the blocker for compatibility with lower ESLint v9 versions was that `processor`. Since CSS does not have a `processor` configured, broader type compatibility can be achieved.
1. As the type compatibility range is now 9.15.0 or above, I intentionally didn’t mention in `README.md` that type compatibility is ensured for v9.15.0 or above, since the current type compatibility range is the same as the one we already support.

https://github.com/eslint/css/blob/4a7a95794ee30b744af80a7f23aa3c685536ad33/README.md?plain=1#L7

## Related Issues

Refs: https://github.com/eslint/markdown/pull/648
Fixes: eslint/json#213

<!-- include tags like "fixes #123" or "refs #123" -->

## Is there anything you'd like reviewers to focus on?

N/A