### PR TITLE
feat: add suggestions to no-empty-blocks

### DIFF
--- a/src/rules/no-empty-blocks.js
+++ b/src/rules/no-empty-blocks.js
@@ -53,21 +53,42 @@ export default /** @satisfies {NoEmptyBlocksRuleDefinition} */ ({
 							? [
 									{
 										messageId: "convertToStatement",
-										fix: fixer =>
-											fixer.replaceTextRange(
+										fix(fixer) {
+											const commentsBeforeBlock =
+												context.sourceCode.comments.filter(
+													comment =>
+														comment.loc.start
+															.offset >=
+															parent.prelude.loc
+																.end.offset &&
+														comment.loc.end
+															.offset <=
+															node.loc.start
+																.offset,
+												);
+											const lastComment =
+												commentsBeforeBlock.at(-1);
+
+											return fixer.replaceTextRange(
 												[
-													parent.prelude.loc.end
-														.offset,
+													lastComment
+														? lastComment.loc.end
+																.offset
+														: parent.prelude.loc.end
+																.offset,
 													node.loc.end.offset,
 												],
 												";",
-											),
+											);
+										},
 									},
 								]
 							: [
 									{
 										messageId: "removeRule",
-										fix: fixer => fixer.remove(parent),
+										fix(fixer) {
+											return fixer.remove(parent);
+										},
 									},
 								],
 					});

--- a/src/rules/no-empty-blocks.js
+++ b/src/rules/no-empty-blocks.js
@@ -9,7 +9,7 @@
 
 /**
  * @import { CSSRuleDefinition } from "../types.js"
- * @typedef {"emptyBlock"} NoEmptyBlocksMessageIds
+ * @typedef {"emptyBlock" | "removeRule" | "convertToStatement"} NoEmptyBlocksMessageIds
  * @typedef {CSSRuleDefinition<{ RuleOptions: [], MessageIds: NoEmptyBlocksMessageIds }>} NoEmptyBlocksRuleDefinition
  */
 
@@ -21,6 +21,8 @@ export default /** @satisfies {NoEmptyBlocksRuleDefinition} */ ({
 	meta: {
 		type: "problem",
 
+		hasSuggestions: true,
+
 		docs: {
 			description: "Disallow empty blocks",
 			recommended: true,
@@ -29,6 +31,8 @@ export default /** @satisfies {NoEmptyBlocksRuleDefinition} */ ({
 
 		messages: {
 			emptyBlock: "Unexpected empty block found.",
+			removeRule: "Remove the empty rule.",
+			convertToStatement: "Convert to layer statement.",
 		},
 	},
 
@@ -36,9 +40,36 @@ export default /** @satisfies {NoEmptyBlocksRuleDefinition} */ ({
 		return {
 			Block(node) {
 				if (node.children.length === 0) {
+					const parent = context.sourceCode.getParent(node);
+					const isNamedAtLayer =
+						parent.type === "Atrule" &&
+						parent.name.toLowerCase() === "layer" &&
+						parent.prelude;
+
 					context.report({
 						loc: node.loc,
 						messageId: "emptyBlock",
+						suggest: isNamedAtLayer
+							? [
+									{
+										messageId: "convertToStatement",
+										fix: fixer =>
+											fixer.replaceTextRange(
+												[
+													parent.prelude.loc.end
+														.offset,
+													node.loc.end.offset,
+												],
+												";",
+											),
+									},
+								]
+							: [
+									{
+										messageId: "removeRule",
+										fix: fixer => fixer.remove(parent),
+									},
+								],
 					});
 				}
 			},

--- a/tests/rules/no-empty-blocks.test.js
+++ b/tests/rules/no-empty-blocks.test.js
@@ -163,10 +163,68 @@ ruleTester.run("no-empty-blocks", rule, {
 			],
 		},
 		{
+			code: "@layer defaults /* comment */ { }",
+			errors: [
+				{
+					messageId: "emptyBlock",
+					line: 1,
+					column: 31,
+					endLine: 1,
+					endColumn: 34,
+					suggestions: [
+						{
+							messageId: "convertToStatement",
+							output: "@layer defaults /* comment */;",
+						},
+					],
+				},
+			],
+		},
+		{
+			code: "@layer defaults /*\n * comment\n */ { }",
+			errors: [
+				{
+					messageId: "emptyBlock",
+					line: 3,
+					column: 5,
+					endLine: 3,
+					endColumn: 8,
+					suggestions: [
+						{
+							messageId: "convertToStatement",
+							output: "@layer defaults /*\n * comment\n */;",
+						},
+					],
+				},
+			],
+		},
+		{
+			code: "@layer defaults /* first */ /* second */ { }",
+			errors: [
+				{
+					messageId: "emptyBlock",
+					line: 1,
+					column: 42,
+					endLine: 1,
+					endColumn: 45,
+					suggestions: [
+						{
+							messageId: "convertToStatement",
+							output: "@layer defaults /* first */ /* second */;",
+						},
+					],
+				},
+			],
+		},
+		{
 			code: "@LAYER foo{}",
 			errors: [
 				{
 					messageId: "emptyBlock",
+					line: 1,
+					column: 11,
+					endLine: 1,
+					endColumn: 13,
 					suggestions: [
 						{
 							messageId: "convertToStatement",
@@ -181,6 +239,10 @@ ruleTester.run("no-empty-blocks", rule, {
 			errors: [
 				{
 					messageId: "emptyBlock",
+					line: 2,
+					column: 2,
+					endLine: 2,
+					endColumn: 5,
 					suggestions: [
 						{
 							messageId: "convertToStatement",

--- a/tests/rules/no-empty-blocks.test.js
+++ b/tests/rules/no-empty-blocks.test.js
@@ -34,6 +34,7 @@ ruleTester.run("no-empty-blocks", rule, {
 					column: 3,
 					endLine: 1,
 					endColumn: 6,
+					suggestions: [{ messageId: "removeRule", output: "" }],
 				},
 			],
 		},
@@ -46,6 +47,7 @@ ruleTester.run("no-empty-blocks", rule, {
 					column: 3,
 					endLine: 1,
 					endColumn: 20,
+					suggestions: [{ messageId: "removeRule", output: "" }],
 				},
 			],
 		},
@@ -58,6 +60,7 @@ ruleTester.run("no-empty-blocks", rule, {
 					column: 3,
 					endLine: 2,
 					endColumn: 2,
+					suggestions: [{ messageId: "removeRule", output: "" }],
 				},
 			],
 		},
@@ -70,6 +73,7 @@ ruleTester.run("no-empty-blocks", rule, {
 					column: 3,
 					endLine: 2,
 					endColumn: 3,
+					suggestions: [{ messageId: "removeRule", output: "" }],
 				},
 			],
 		},
@@ -82,6 +86,12 @@ ruleTester.run("no-empty-blocks", rule, {
 					column: 14,
 					endLine: 1,
 					endColumn: 17,
+					suggestions: [
+						{
+							messageId: "removeRule",
+							output: "",
+						},
+					],
 				},
 			],
 		},
@@ -94,6 +104,12 @@ ruleTester.run("no-empty-blocks", rule, {
 					column: 3,
 					endLine: 1,
 					endColumn: 6,
+					suggestions: [
+						{
+							messageId: "removeRule",
+							output: "\n@media print { \nb { } \n}", // only a{} was removed
+						},
+					],
 				},
 				{
 					messageId: "emptyBlock",
@@ -101,6 +117,156 @@ ruleTester.run("no-empty-blocks", rule, {
 					column: 3,
 					endLine: 3,
 					endColumn: 6,
+					suggestions: [
+						{
+							messageId: "removeRule",
+							output: "a { }\n@media print { \n \n}", // only b{} was removed
+						},
+					],
+				},
+			],
+		},
+		{
+			code: "@layer defaults { \n }",
+			errors: [
+				{
+					messageId: "emptyBlock",
+					line: 1,
+					column: 17,
+					endLine: 2,
+					endColumn: 3,
+					suggestions: [
+						{
+							messageId: "convertToStatement",
+							output: "@layer defaults;",
+						},
+					],
+				},
+			],
+		},
+		{
+			code: "@layer a, b { \n }",
+			errors: [
+				{
+					messageId: "emptyBlock",
+					line: 1,
+					column: 13,
+					endLine: 2,
+					endColumn: 3,
+					suggestions: [
+						{
+							messageId: "convertToStatement",
+							output: "@layer a, b;",
+						},
+					],
+				},
+			],
+		},
+		{
+			code: "@LAYER foo{}",
+			errors: [
+				{
+					messageId: "emptyBlock",
+					suggestions: [
+						{
+							messageId: "convertToStatement",
+							output: "@LAYER foo;",
+						},
+					],
+				},
+			],
+		},
+		{
+			code: "@laYer foo\n\t{ }",
+			errors: [
+				{
+					messageId: "emptyBlock",
+					suggestions: [
+						{
+							messageId: "convertToStatement",
+							output: "@laYer foo;",
+						},
+					],
+				},
+			],
+		},
+		{
+			code: "@layer { \n }",
+			errors: [
+				{
+					messageId: "emptyBlock",
+					line: 1,
+					column: 8,
+					endLine: 2,
+					endColumn: 3,
+					suggestions: [
+						{
+							messageId: "removeRule",
+							output: "",
+						},
+					],
+				},
+			],
+		},
+		{
+			code: "@supports not selector(h2 > p) { }",
+			errors: [
+				{
+					messageId: "emptyBlock",
+					line: 1,
+					column: 32,
+					endLine: 1,
+					endColumn: 35,
+					suggestions: [
+						{
+							messageId: "removeRule",
+							output: "",
+						},
+					],
+				},
+			],
+		},
+		{
+			code: "@keyframes a { 0% {} 100% {} }",
+			errors: [
+				{
+					messageId: "emptyBlock",
+					line: 1,
+					column: 19,
+					endLine: 1,
+					endColumn: 21,
+					suggestions: [
+						{
+							messageId: "removeRule",
+							output: "@keyframes a {  100% {} }",
+						},
+					],
+				},
+				{
+					messageId: "emptyBlock",
+					line: 1,
+					column: 27,
+					endLine: 1,
+					endColumn: 29,
+					suggestions: [
+						{
+							messageId: "removeRule",
+							output: "@keyframes a { 0% {}  }",
+						},
+					],
+				},
+			],
+		},
+		{
+			code: "@keyframes a { }",
+			errors: [
+				{
+					messageId: "emptyBlock",
+					line: 1,
+					column: 14,
+					endLine: 1,
+					endColumn: 17,
+					suggestions: [{ messageId: "removeRule", output: "" }],
 				},
 			],
 		},


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).


#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] ~~(If the above is not checked) I have reviewed the AI-generated content before submitting.~~

#### What is the purpose of this pull request?

Add sugggestions to `no-empty-blocks`. There are two different cases:

* `@layer name {}`  becomes `@layer name`
* all other empty blocks like `a {}` become ` `. This included unnamed layers such as `@layer {}`. 

#### What changes did you make? (Give an overview)

#### Related Issues

Closes #476

#### Is there anything you'd like reviewers to focus on?

- We don't check if a block contains comments, because that would be convered by #477
- To the best of my knowledge, deleting all these different types of empty blocks is safe (except [`@layer`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@layer) as mentioned above). I have asked a senior colleague and Claude Opus 4.8, both of whom agreed.