### PR TITLE
refactor: simplify prefer-logical-properties lookups

### DIFF
--- a/src/rules/prefer-logical-properties.js
+++ b/src/rules/prefer-logical-properties.js
@@ -182,11 +182,11 @@ export default /** @satisfies {PreferLogicalPropertiesRuleDefinition} */ ({
 			notLogicalUnit:
 				"Expected logical unit '{{replacement}}' instead of '{{unit}}'.",
 			replaceWithLogicalProperty:
-				"Replace '{{original}}' with logical property '{{replacement}}'.",
+				"Replace '{{property}}' with logical property '{{replacement}}'.",
 			replaceWithLogicalValue:
-				"Replace '{{original}}' with logical value '{{replacement}}'.",
+				"Replace '{{value}}' with logical value '{{replacement}}'.",
 			replaceWithLogicalUnit:
-				"Replace '{{original}}' with logical unit '{{replacement}}'.",
+				"Replace '{{unit}}' with logical unit '{{replacement}}'.",
 		},
 	},
 
@@ -200,26 +200,27 @@ export default /** @satisfies {PreferLogicalPropertiesRuleDefinition} */ ({
 					return;
 				}
 
+				const propertyReplacement = propertiesReplacements.get(
+					node.property,
+				);
+
 				if (
-					propertiesReplacements.get(node.property) &&
+					propertyReplacement &&
 					!allowProperties.includes(node.property)
 				) {
-					const replacement = propertiesReplacements.get(
-						node.property,
-					);
 					context.report({
 						loc: node.loc,
 						messageId: "notLogicalProperty",
 						data: {
 							property: node.property,
-							replacement,
+							replacement: propertyReplacement,
 						},
 						suggest: [
 							{
 								messageId: "replaceWithLogicalProperty",
 								data: {
-									original: node.property,
-									replacement,
+									property: node.property,
+									replacement: propertyReplacement,
 								},
 								fix(fixer) {
 									return fixer.replaceTextRange(
@@ -228,7 +229,7 @@ export default /** @satisfies {PreferLogicalPropertiesRuleDefinition} */ ({
 											node.loc.start.offset +
 												node.property.length,
 										],
-										replacement,
+										propertyReplacement,
 									);
 								},
 							},
@@ -236,71 +237,68 @@ export default /** @satisfies {PreferLogicalPropertiesRuleDefinition} */ ({
 					});
 				}
 
+				const valueReplacements = propertyValuesReplacements.get(
+					node.property,
+				);
+
 				if (
-					propertyValuesReplacements.get(node.property) &&
+					valueReplacements &&
 					node.value.type === "Value" &&
 					node.value.children[0].type === "Identifier"
 				) {
 					const identifier = node.value.children[0];
 					const nodeValue = identifier.name;
-					if (
-						propertyValuesReplacements.get(node.property)[nodeValue]
-					) {
-						const replacement = propertyValuesReplacements.get(
-							node.property,
-						)[nodeValue];
-						if (replacement) {
-							context.report({
-								loc: identifier.loc,
-								messageId: "notLogicalValue",
-								data: {
-									value: nodeValue,
-									replacement,
-								},
-								suggest: [
-									{
-										messageId: "replaceWithLogicalValue",
-										data: {
-											original: nodeValue,
-											replacement,
-										},
-										fix(fixer) {
-											return fixer.replaceText(
-												identifier,
-												replacement,
-											);
-										},
+					const valueReplacement = valueReplacements[nodeValue];
+
+					if (valueReplacement) {
+						context.report({
+							loc: identifier.loc,
+							messageId: "notLogicalValue",
+							data: {
+								value: nodeValue,
+								replacement: valueReplacement,
+							},
+							suggest: [
+								{
+									messageId: "replaceWithLogicalValue",
+									data: {
+										value: nodeValue,
+										replacement: valueReplacement,
 									},
-								],
-							});
-						}
+									fix(fixer) {
+										return fixer.replaceText(
+											identifier,
+											valueReplacement,
+										);
+									},
+								},
+							],
+						});
 					}
 				}
 			},
 			Dimension(node) {
-				if (
-					unitReplacements.get(node.unit) &&
-					!allowUnits.includes(node.unit)
-				) {
-					const replacement = unitReplacements.get(node.unit);
+				const unitReplacement = unitReplacements.get(node.unit);
+
+				if (unitReplacement && !allowUnits.includes(node.unit)) {
 					context.report({
 						loc: node.loc,
 						messageId: "notLogicalUnit",
 						data: {
 							unit: node.unit,
-							replacement,
+							replacement: unitReplacement,
 						},
 						suggest: [
 							{
 								messageId: "replaceWithLogicalUnit",
 								data: {
-									original: node.unit,
-									replacement,
+									unit: node.unit,
+									replacement: unitReplacement,
 								},
 								fix(fixer) {
 									return fixer.replaceText(
 										node,
-										node.value + replacement,
+										node.value + unitReplacement,
 									);
 								},
 							},

--- a/tests/rules/prefer-logical-properties.test.js
+++ b/tests/rules/prefer-logical-properties.test.js
@@ -59,7 +59,11 @@ ruleTester.run("prefer-logical-properties", rule, {
 					},
 					suggestions: [
 						{
-							desc: "Replace 'margin-top' with logical property 'margin-block-start'.",
+							messageId: "replaceWithLogicalProperty",
+							data: {
+								property: "margin-top",
+								replacement: "margin-block-start",
+							},
 							output: "a { margin-block-start: 10px; }",
 						},
 					],
@@ -81,7 +85,11 @@ ruleTester.run("prefer-logical-properties", rule, {
 					},
 					suggestions: [
 						{
-							desc: "Replace 'padding-top' with logical property 'padding-block-start'.",
+							messageId: "replaceWithLogicalProperty",
+							data: {
+								property: "padding-top",
+								replacement: "padding-block-start",
+							},
 							output: "a { padding-block-start: 20px; }",
 						},
 					],
@@ -103,7 +111,11 @@ ruleTester.run("prefer-logical-properties", rule, {
 					},
 					suggestions: [
 						{
-							desc: "Replace 'left' with logical value 'start'.",
+							messageId: "replaceWithLogicalValue",
+							data: {
+								value: "left",
+								replacement: "start",
+							},
 							output: "a { text-align: start }",
 						},
 					],
@@ -125,7 +137,11 @@ ruleTester.run("prefer-logical-properties", rule, {
 					},
 					suggestions: [
 						{
-							desc: "Replace 'vh' with logical unit 'vb'.",
+							messageId: "replaceWithLogicalUnit",
+							data: {
+								unit: "vh",
+								replacement: "vb",
+							},
 							output: "a { block-size: 100vb }",
 						},
 					],


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

This PR refactors the `prefer-logical-properties` rule to reduce redundant map lookups.

#### What changes did you make? (Give an overview)

- Reused local replacement variables for properties, values, and units instead of repeating map lookups.
- Updated suggestion message templates to use specific data keys: `property`, `value`, and `unit`.
- Updated rule tests to assert suggestion `messageId` and `data` instead of descriptions.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
