### PR TITLE
ci: add explicit permissions to update-baseline.yml

### DIFF
--- a/.github/workflows/update-baseline.yml
+++ b/.github/workflows/update-baseline.yml
@@ -4,6 +4,9 @@ on:
     schedule:
         - cron: "0 0 * * 0" # Runs every Sunday at midnight UTC
 
+permissions:
+    contents: read
+
 jobs:
     update-baseline:
         runs-on: ubuntu-latest


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

Most workflow files explicitly declare permissions, but `update-baseline.yml` was missing this and relying on the default `GITHUB_TOKEN` permissions. Since it doesn't perform any write operations besides checkout, restricting it to `contents: read` should be sufficient.

#### What changes did you make? (Give an overview)

I've added explicit permissions to `update-baseline.yml` as shown below:

```yml
permissions:
    contents: read
```

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
