### PR TITLE
fix: distinguish named timeline range keyframe selectors

### DIFF
--- a/src/rules/no-duplicate-keyframe-selectors.js
+++ b/src/rules/no-duplicate-keyframe-selectors.js
@@ -53,26 +53,29 @@ export default /** @satisfies {DuplicateKeyframeSelectorRuleDefinition} */ ({
 				}
 
 				// @ts-ignore - children is a valid property for prelude
-				const selector = node.prelude.children[0].children[0];
-				let value;
-				if (selector.type === "Percentage") {
-					value = `${selector.value}%`;
-				} else if (selector.type === "TypeSelector") {
-					value = selector.name.toLowerCase();
-				} else {
-					value = selector.value;
-				}
+				const selector = node.prelude.children[0];
+				const value = [];
 
-				if (seen.has(value)) {
+				selector.children.forEach(component => {
+					if (component.type === "Percentage") {
+						value.push(`${component.value}%`);
+					} else if (component.type === "TypeSelector") {
+						value.push(component.name.toLowerCase());
+					}
+				});
+
+				const key = value.join(" ");
+
+				if (seen.has(key)) {
 					context.report({
 						loc: selector.loc,
 						messageId: "duplicateKeyframeSelector",
 						data: {
-							selector: value,
+							selector: key,
 						},
 					});
 				} else {
-					seen.set(value, true);
+					seen.set(key, true);
 				}
 			},
 		};

--- a/tests/rules/no-duplicate-keyframe-selectors.test.js
+++ b/tests/rules/no-duplicate-keyframe-selectors.test.js
@@ -418,5 +418,53 @@ ruleTester.run("no-duplicate-keyframe-selectors", rule, {
 				},
 			],
 		},
+		{
+			code: dedent`@keyframes test {
+                entry 0% { opacity: 0; }
+                entry  0% { opacity: 1; }
+            }`,
+			errors: [
+				{
+					messageId: "duplicateKeyframeSelector",
+					data: { selector: "entry 0%" },
+					line: 3,
+					column: 5,
+					endLine: 3,
+					endColumn: 14,
+				},
+			],
+		},
+		{
+			code: dedent`@keyframes test {
+                exit 100% { opacity: 0; }
+                exit /* comment */ 100% { opacity: 1; }
+            }`,
+			errors: [
+				{
+					messageId: "duplicateKeyframeSelector",
+					data: { selector: "exit 100%" },
+					line: 3,
+					column: 5,
+					endLine: 3,
+					endColumn: 28,
+				},
+			],
+		},
+		{
+			code: dedent`@keyframes test {
+                ENTRY 0% { opacity: 0; }
+                entry 0% { opacity: 1; }
+            }`,
+			errors: [
+				{
+					messageId: "duplicateKeyframeSelector",
+					data: { selector: "entry 0%" },
+					line: 3,
+					column: 5,
+					endLine: 3,
+					endColumn: 13,
+				},
+			],
+		},
 	],
 });

--- a/tests/rules/no-duplicate-keyframe-selectors.test.js
+++ b/tests/rules/no-duplicate-keyframe-selectors.test.js
@@ -77,6 +77,12 @@ ruleTester.run("no-duplicate-keyframe-selectors", rule, {
             50% { opacity: 0.5; }
             to { opacity: 1; }
         }`,
+		dedent`@keyframes test {
+            entry 0% { opacity: 0; }
+            entry 100% { opacity: 1; }
+            exit 0% { opacity: 1; }
+            exit 100% { opacity: 0; }
+        }`,
 	],
 	invalid: [
 		{
@@ -393,6 +399,22 @@ ruleTester.run("no-duplicate-keyframe-selectors", rule, {
 					column: 5,
 					endLine: 18,
 					endColumn: 8,
+				},
+			],
+		},
+		{
+			code: dedent`@keyframes test {
+                entry 0% { opacity: 0; }
+                entry 0% { opacity: 1; }
+            }`,
+			errors: [
+				{
+					messageId: "duplicateKeyframeSelector",
+					data: { selector: "entry 0%" },
+					line: 3,
+					column: 5,
+					endLine: 3,
+					endColumn: 13,
 				},
 			],
 		},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What did you do?

```css
/* eslint css/no-duplicate-keyframe-selectors: "error" */

@keyframes in-and-out {
  entry 0% {}
  entry 100% {}
  exit 0% {}
  exit 100% {}
}
```

#### What did you expect to happen?

No duplicate-selector errors, because each range/percentage pair is distinct.

#### What actually happened?

The rule used only the selector’s first component (`entry` or `exit`), so it incorrectly reported `entry 100%` and `exit 100%` as duplicates.

#### What is the purpose of this pull request?

This PR fixes false duplicate-selector reports for `@keyframes` selectors that include a named timeline range.

#### What changes did you make? (Give an overview)

Updated `no-duplicate-keyframe-selectors` to use the complete keyframe selector when detecting duplicates.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
