### PR TITLE
fix: skip validating values containing env() in no-invalid-properties

### DIFF
--- a/src/rules/no-invalid-properties.js
+++ b/src/rules/no-invalid-properties.js
@@ -7,7 +7,11 @@
 // Imports
 //-----------------------------------------------------------------------------
 
-import { isSyntaxMatchError, isSyntaxReferenceError } from "../util.js";
+import {
+	isSyntaxMatchError,
+	isSyntaxReferenceError,
+	isEnvMatchError,
+} from "../util.js";
 
 //-----------------------------------------------------------------------------
 // Type Definitions
@@ -463,7 +467,13 @@ export default /** @satisfies {NoInvalidPropertiesRuleDefinition} */ ({
 						});
 						return;
 					}
-
+					if (isEnvMatchError(error)) {
+						/*
+						 * env() values are provided by the user agent and
+						 * cannot be validated, so skip validation entirely.
+						 */
+						return;
+					}
 					if (
 						!allowUnknownVariables ||
 						isSyntaxReferenceError(error)

--- a/src/util.js
+++ b/src/util.js
@@ -32,3 +32,13 @@ export function isSyntaxMatchError(error) {
 export function isSyntaxReferenceError(error) {
 	return typeof error.reference === "string";
 }
+
+/**
+ * Determines if an error is the lexer error thrown when a value containing
+ * `env()` cannot be matched against a syntax definition.
+ * @param {Object} error The error object to check.
+ * @returns {boolean} True if the error is the `env()` match error, false if not.
+ */
+export function isEnvMatchError(error) {
+	return error.message === "Matching for a tree with env() is not supported";
+}

--- a/tests/rules/no-invalid-properties.test.js
+++ b/tests/rules/no-invalid-properties.test.js
@@ -30,6 +30,7 @@ ruleTester.run("no-invalid-properties", rule, {
 		"a { padding-top: calc(env(safe-area-inset-top) + 10px); }",
 		"a { width: env(titlebar-area-width); }",
 		"a { padding: env(safe-area-inset-top) 0 env(safe-area-inset-bottom) 0; }",
+		"a { padding: env(safe-area-inset-top) red }",
 		"a { color: red; background-color: blue; }",
 		"a { color: red; transition: none; }",
 		"body { --custom-property: red; }",

--- a/tests/rules/no-invalid-properties.test.js
+++ b/tests/rules/no-invalid-properties.test.js
@@ -25,6 +25,11 @@ const ruleTester = new RuleTester({
 ruleTester.run("no-invalid-properties", rule, {
 	valid: [
 		"a { color: red; }",
+		"a { padding-top: env(safe-area-inset-top); }",
+		"a { padding-top: env(safe-area-inset-top, 20px); }",
+		"a { padding-top: calc(env(safe-area-inset-top) + 10px); }",
+		"a { width: env(titlebar-area-width); }",
+		"a { padding: env(safe-area-inset-top) 0 env(safe-area-inset-bottom) 0; }",
 		"a { color: red; background-color: blue; }",
 		"a { color: red; transition: none; }",
 		"body { --custom-property: red; }",
@@ -276,6 +281,19 @@ ruleTester.run("no-invalid-properties", rule, {
 		"main { p:first-of-type, span { color: red; } }",
 	],
 	invalid: [
+		{
+			code: "a { paddin-top: env(safe-area-inset-top); }",
+			errors: [
+				{
+					messageId: "unknownProperty",
+					data: { property: "paddin-top" },
+					line: 1,
+					column: 5,
+					endLine: 1,
+					endColumn: 15,
+				},
+			],
+		},
 		{
 			code: "a { color: bar }",
 			errors: [

--- a/tests/rules/no-invalid-properties.test.js
+++ b/tests/rules/no-invalid-properties.test.js
@@ -25,12 +25,6 @@ const ruleTester = new RuleTester({
 ruleTester.run("no-invalid-properties", rule, {
 	valid: [
 		"a { color: red; }",
-		"a { padding-top: env(safe-area-inset-top); }",
-		"a { padding-top: env(safe-area-inset-top, 20px); }",
-		"a { padding-top: calc(env(safe-area-inset-top) + 10px); }",
-		"a { width: env(titlebar-area-width); }",
-		"a { padding: env(safe-area-inset-top) 0 env(safe-area-inset-bottom) 0; }",
-		"a { padding: env(safe-area-inset-top) red }",
 		"a { color: red; background-color: blue; }",
 		"a { color: red; transition: none; }",
 		"body { --custom-property: red; }",
@@ -280,41 +274,16 @@ ruleTester.run("no-invalid-properties", rule, {
 		"main { p:has(.child) { color: red; } }",
 		"main { p:has(.child:hover) { color: red; } }",
 		"main { p:first-of-type, span { color: red; } }",
+
+		// env() values are provided by the user agent and cannot be validated
+		"a { padding-top: env(safe-area-inset-top); }",
+		"a { padding-top: env(safe-area-inset-top, 20px); }",
+		"a { padding-top: calc(env(safe-area-inset-top) + 10px); }",
+		"a { width: env(titlebar-area-width); }",
+		"a { padding: env(safe-area-inset-top) 0 env(safe-area-inset-bottom) 0; }",
+		"a { padding: env(safe-area-inset-top) red }",
 	],
 	invalid: [
-		{
-			code: "a { paddin-top: env(safe-area-inset-top); }",
-			errors: [
-				{
-					messageId: "unknownProperty",
-					data: { property: "paddin-top" },
-					line: 1,
-					column: 5,
-					endLine: 1,
-					endColumn: 15,
-				},
-			],
-		},
-
-		/*
-		 * Reporting an unknown `var()` nested inside `env()` is intentional:
-		 * this rule also checks that custom properties are resolvable, and that
-		 * check is independent of the syntax validation skipped for `env()`.
-		 * We can revisit this once the rule supports partial validation of values.
-		 */
-		{
-			code: "a { padding: env(safe-area-inset-top, var(--external-padding)); }",
-			errors: [
-				{
-					messageId: "unknownVar",
-					data: { var: "--external-padding" },
-					line: 1,
-					column: 43,
-					endLine: 1,
-					endColumn: 61,
-				},
-			],
-		},
 		{
 			code: "a { color: bar }",
 			errors: [
@@ -1490,6 +1459,39 @@ ruleTester.run("no-invalid-properties", rule, {
 					column: 56,
 					endLine: 1,
 					endColumn: 63,
+				},
+			],
+		},
+		{
+			code: "a { paddin-top: env(safe-area-inset-top); }",
+			errors: [
+				{
+					messageId: "unknownProperty",
+					data: { property: "paddin-top" },
+					line: 1,
+					column: 5,
+					endLine: 1,
+					endColumn: 15,
+				},
+			],
+		},
+
+		/*
+		 * Reporting an unknown `var()` nested inside `env()` is intentional:
+		 * this rule also checks that custom properties are resolvable, and that
+		 * check is independent of the syntax validation skipped for `env()`.
+		 * We can revisit this once the rule supports partial validation of values.
+		 */
+		{
+			code: "a { padding: env(safe-area-inset-top, var(--external-padding)); }",
+			errors: [
+				{
+					messageId: "unknownVar",
+					data: { var: "--external-padding" },
+					line: 1,
+					column: 43,
+					endLine: 1,
+					endColumn: 61,
 				},
 			],
 		},

--- a/tests/rules/no-invalid-properties.test.js
+++ b/tests/rules/no-invalid-properties.test.js
@@ -295,6 +295,26 @@ ruleTester.run("no-invalid-properties", rule, {
 				},
 			],
 		},
+
+		/*
+		 * Reporting an unknown `var()` nested inside `env()` is intentional:
+		 * this rule also checks that custom properties are resolvable, and that
+		 * check is independent of the syntax validation skipped for `env()`.
+		 * We can revisit this once the rule supports partial validation of values.
+		 */
+		{
+			code: "a { padding: env(safe-area-inset-top, var(--external-padding)); }",
+			errors: [
+				{
+					messageId: "unknownVar",
+					data: { var: "--external-padding" },
+					line: 1,
+					column: 43,
+					endLine: 1,
+					endColumn: 61,
+				},
+			],
+		},
 		{
 			code: "a { color: bar }",
 			errors: [


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?
Fixes a false positive in `no-invalid-properties`: any declaration whose value contains `env()` was reported as `Unknown property '...' found`, even for obviously valid properties like `padding-top`.

#### What changes did you make? (Give an overview)

As noted in #509, the csstree fork bails out with a plain Error ("Matching for a tree with env() is not supported") when a value contains `env()`, but the rule was routing that error to the `unknownProperty` report.

I added an `isEnvMatchError()` helper to `src/util.js` and made the rule skip validation when that error occurs, since `env()` values come from the user agent and can't be validated anyway.

Unknown property names are still reported for declarations with `env()` values, because the lexer checks the property reference before the `env()` check — added an invalid test (`paddin-top: env(...)`) to lock that in, plus valid tests for `env()` alone, with a fallback, inside `calc()`, and in a shorthand.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->
fixes #509

#### Is there anything you'd like reviewers to focus on?
`isEnvMatchError()` matches the lexer's error by its exact message string. Let me know if there's a better way to detect this error.