### PR TITLE
fix: detect equivalent selectors in `no-duplicate-keyframe-selectors`

### DIFF
--- a/docs/rules/no-duplicate-keyframe-selectors.md
+++ b/docs/rules/no-duplicate-keyframe-selectors.md
@@ -18,11 +18,11 @@ The [`@keyframes` at-rule](https://developer.mozilla.org/en-US/docs/Web/CSS/@key
 }
 ```
 
-If a selector is repeated within the same @keyframes block, the last declaration wins, potentially causing unintentional overrides or confusion.
+If a selector is repeated within the same `@keyframes` block, the last declaration wins, potentially causing unintentional overrides or confusion.
 
 ## Rule Details
 
-This rule warns when it finds a keyframe block that contains duplicate selectors.
+This rule warns when it finds a keyframe block that contains duplicate selectors. It treats `from` and `0%` as equivalent selectors, as well as `to` and `100%`.
 
 Examples of **incorrect** code for this rule:
 
@@ -60,6 +60,24 @@ Examples of **incorrect** code for this rule:
 
 	to {
 		opacity: 1;
+	}
+}
+
+@keyframes test {
+	from {
+		opacity: 0;
+	}
+
+	0% {
+		opacity: 0.25;
+	}
+
+	to {
+		opacity: 1;
+	}
+
+	100% {
+		opacity: 0.75;
 	}
 }
 ```

--- a/src/rules/no-duplicate-keyframe-selectors.js
+++ b/src/rules/no-duplicate-keyframe-selectors.js
@@ -14,6 +14,15 @@
  */
 
 //-----------------------------------------------------------------------------
+// Helpers
+//-----------------------------------------------------------------------------
+
+const keyframeSelectorAliases = new Map([
+	["from", "0%"],
+	["to", "100%"],
+]);
+
+//-----------------------------------------------------------------------------
 // Rule Definition
 //-----------------------------------------------------------------------------
 
@@ -64,14 +73,21 @@ export default /** @satisfies {DuplicateKeyframeSelectorRuleDefinition} */ ({
 					}
 				});
 
-				const key = value.join(" ");
+				const selectorValue = value.join(" ");
+				const key = value
+					.map(
+						selectorPart =>
+							keyframeSelectorAliases.get(selectorPart) ??
+							selectorPart,
+					)
+					.join(" ");
 
 				if (seen.has(key)) {
 					context.report({
 						loc: selector.loc,
 						messageId: "duplicateKeyframeSelector",
 						data: {
-							selector: key,
+							selector: selectorValue,
 						},
 					});
 				} else {

--- a/tests/rules/no-duplicate-keyframe-selectors.test.js
+++ b/tests/rules/no-duplicate-keyframe-selectors.test.js
@@ -466,5 +466,83 @@ ruleTester.run("no-duplicate-keyframe-selectors", rule, {
 				},
 			],
 		},
+		{
+			code: dedent`@keyframes test {
+			    from { opacity: 0; }
+			    0% { opacity: 0.25; }
+			    to { opacity: 1; }
+			    100% { opacity: 0.75; }
+			}`,
+			errors: [
+				{
+					messageId: "duplicateKeyframeSelector",
+					data: { selector: "0%" },
+					line: 3,
+					column: 5,
+					endLine: 3,
+					endColumn: 7,
+				},
+				{
+					messageId: "duplicateKeyframeSelector",
+					data: { selector: "100%" },
+					line: 5,
+					column: 5,
+					endLine: 5,
+					endColumn: 9,
+				},
+			],
+		},
+		{
+			code: dedent`@keyframes test {
+                FROM { opacity: 0; }
+                0% { opacity: 0.25; }
+                To { opacity: 1; }
+                100% { opacity: 0.75; }
+            }`,
+			errors: [
+				{
+					messageId: "duplicateKeyframeSelector",
+					data: { selector: "0%" },
+					line: 3,
+					column: 5,
+					endLine: 3,
+					endColumn: 7,
+				},
+				{
+					messageId: "duplicateKeyframeSelector",
+					data: { selector: "100%" },
+					line: 5,
+					column: 5,
+					endLine: 5,
+					endColumn: 9,
+				},
+			],
+		},
+		{
+			code: dedent`@keyframes test {
+                0% { opacity: 0; }
+                From { opacity: 0.25; }
+                100% { opacity: 1; }
+                TO { opacity: 0.75; }
+            }`,
+			errors: [
+				{
+					messageId: "duplicateKeyframeSelector",
+					data: { selector: "from" },
+					line: 3,
+					column: 5,
+					endLine: 3,
+					endColumn: 9,
+				},
+				{
+					messageId: "duplicateKeyframeSelector",
+					data: { selector: "to" },
+					line: 5,
+					column: 5,
+					endLine: 5,
+					endColumn: 7,
+				},
+			],
+		},
 	],
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

This PR makes `no-duplicate-keyframe-selectors` report equivalent `from`/`0%` and `to`/`100%` keyframe selectors as duplicates.

#### What changes did you make? (Give an overview)

- Canonicalized `from` to `0%` and `to` to `100%` for duplicate detection.
- Updated the rule documentation.
- Added tests.

#### Related Issues

Fixes #508

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
