### PR TITLE
refactor: no-duplicate-keyframe-selectors use Set instead of Map

### DIFF
--- a/src/rules/no-duplicate-keyframe-selectors.js
+++ b/src/rules/no-duplicate-keyframe-selectors.js
@@ -44,7 +44,7 @@ export default /** @satisfies {DuplicateKeyframeSelectorRuleDefinition} */ ({
 
 	create(context) {
 		let insideKeyframes = false;
-		const seen = new Map();
+		const seen = new Set();
 
 		return {
 			"Atrule[name=/^(-(o|moz|webkit)-)?keyframes$/i]"() {
@@ -91,7 +91,7 @@ export default /** @satisfies {DuplicateKeyframeSelectorRuleDefinition} */ ({
 						},
 					});
 				} else {
-					seen.set(key, true);
+					seen.add(key);
 				}
 			},
 		};


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?
While reviewing #512 I saw the unneeded `Map` usage.
As the value of the key is unused, it is more idiomatic to use a `Set`.

#### What changes did you make? (Give an overview)
Use a `Map` instead of `Set` to keep track of duplicates.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
