### PR TITLE
feat: make font-family-fallbacks generic fonts case-insensitive

### DIFF
--- a/src/rules/font-family-fallbacks.js
+++ b/src/rules/font-family-fallbacks.js
@@ -33,6 +33,26 @@ const genericFonts = new Set([
 	"fangsong",
 ]);
 
+/*
+ * Matches a generic font family as a whole word, for the single value `font`
+ * branch that searches the shorthand where the family sits next to the size.
+ * A name such as `MySerifFont` must not match.
+ */
+const genericFontPattern = new RegExp(
+	String.raw`(?<![\w-])(?:${[...genericFonts].join("|")})(?![\w-])`,
+	"iu",
+);
+
+/**
+ * Check if the name is a generic font family.
+ * Generic font families are keywords, so they are matched case-insensitively.
+ * @param {string} name The name to check.
+ * @returns {boolean} True if the name is a generic font family, false otherwise.
+ */
+function isGenericFont(name) {
+	return genericFonts.has(name.toLowerCase());
+}
+
 /**
  * Check if the value is a CSS-wide keyword.
  * @param {string} value The value to check.
@@ -87,9 +107,9 @@ function reportFontWithoutFallbacksInFontProperty(
 	const valueList = fontPropertyValues.split(",").map(v => v.trim());
 
 	if (valueList.length === 1) {
-		const containsGenericFont = Array.from(genericFonts).some(font =>
-			valueList[0].includes(font),
-		);
+		// A quoted name is a family name, not a keyword
+		const unquoted = valueList[0].replace(/"[^"]*"|'[^']*'/gu, "");
+		const containsGenericFont = genericFontPattern.test(unquoted);
 
 		if (!containsGenericFont) {
 			context.report({
@@ -98,7 +118,7 @@ function reportFontWithoutFallbacksInFontProperty(
 			});
 		}
 	} else {
-		if (!genericFonts.has(valueList.at(-1))) {
+		if (!isGenericFont(valueList.at(-1))) {
 			context.report({
 				loc: node.loc,
 				messageId: "useGenericFont",
@@ -180,13 +200,13 @@ export default /** @satisfies {FontFamilyFallbacksRuleDefinition} */ ({
 
 						if (
 							variableList.length === 1 &&
-							!genericFonts.has(variableList[0])
+							!isGenericFont(variableList[0])
 						) {
 							context.report({
 								loc: node.loc,
 								messageId: "useFallbackFonts",
 							});
-						} else if (!genericFonts.has(variableList.at(-1))) {
+						} else if (!isGenericFont(variableList.at(-1))) {
 							context.report({
 								loc: node.loc,
 								messageId: "useGenericFont",
@@ -195,7 +215,7 @@ export default /** @satisfies {FontFamilyFallbacksRuleDefinition} */ ({
 					} else {
 						if (
 							valueArr[0].type === "Identifier" &&
-							genericFonts.has(valueArr[0].name)
+							isGenericFont(valueArr[0].name)
 						) {
 							return;
 						}
@@ -230,7 +250,10 @@ export default /** @satisfies {FontFamilyFallbacksRuleDefinition} */ ({
 
 						valueArr.forEach(child => {
 							if (child.type === "String") {
-								fontsList.push(child.value);
+								// Keep the quotes so it is not read as a keyword
+								fontsList.push(
+									sourceCode.getText(child).trim(),
+								);
 							}
 
 							if (child.type === "Identifier") {
@@ -258,7 +281,7 @@ export default /** @satisfies {FontFamilyFallbacksRuleDefinition} */ ({
 
 						if (
 							fontsList.length > 0 &&
-							!genericFonts.has(fontsList.at(-1))
+							!isGenericFont(fontsList.at(-1))
 						) {
 							context.report({
 								loc: node.loc,
@@ -270,7 +293,7 @@ export default /** @satisfies {FontFamilyFallbacksRuleDefinition} */ ({
 
 						if (!(
 							lastFont.type === "Identifier" &&
-							genericFonts.has(lastFont.name)
+							isGenericFont(lastFont.name)
 						)) {
 							context.report({
 								loc: node.loc,
@@ -352,9 +375,7 @@ export default /** @satisfies {FontFamilyFallbacksRuleDefinition} */ ({
 								);
 
 								if (!usingVar) {
-									if (
-										!genericFonts.has(afterOperator.at(-1))
-									) {
+									if (!isGenericFont(afterOperator.at(-1))) {
 										context.report({
 											loc: node.loc,
 											messageId: "useGenericFont",
@@ -386,9 +407,7 @@ export default /** @satisfies {FontFamilyFallbacksRuleDefinition} */ ({
 
 										if (
 											variableList.length > 0 &&
-											!genericFonts.has(
-												variableList.at(-1),
-											)
+											!isGenericFont(variableList.at(-1))
 										) {
 											context.report({
 												loc: node.loc,
@@ -397,9 +416,7 @@ export default /** @satisfies {FontFamilyFallbacksRuleDefinition} */ ({
 										}
 									} else {
 										if (
-											!genericFonts.has(
-												afterOperator.at(-1),
-											)
+											!isGenericFont(afterOperator.at(-1))
 										) {
 											context.report({
 												loc: node.loc,
@@ -441,7 +458,7 @@ export default /** @satisfies {FontFamilyFallbacksRuleDefinition} */ ({
 								);
 							} else {
 								if (
-									!genericFonts.has(
+									!isGenericFont(
 										sourceCode
 											.getText(valueArr.at(-1))
 											.trim(),

--- a/src/rules/font-family-fallbacks.js
+++ b/src/rules/font-family-fallbacks.js
@@ -251,9 +251,7 @@ export default /** @satisfies {FontFamilyFallbacksRuleDefinition} */ ({
 						valueArr.forEach(child => {
 							if (child.type === "String") {
 								// Keep the quotes so it is not read as a keyword
-								fontsList.push(
-									sourceCode.getText(child),
-								);
+								fontsList.push(sourceCode.getText(child));
 							}
 
 							if (child.type === "Identifier") {

--- a/src/rules/font-family-fallbacks.js
+++ b/src/rules/font-family-fallbacks.js
@@ -252,7 +252,7 @@ export default /** @satisfies {FontFamilyFallbacksRuleDefinition} */ ({
 							if (child.type === "String") {
 								// Keep the quotes so it is not read as a keyword
 								fontsList.push(
-									sourceCode.getText(child).trim(),
+									sourceCode.getText(child),
 								);
 							}
 

--- a/tests/rules/font-family-fallbacks.test.js
+++ b/tests/rules/font-family-fallbacks.test.js
@@ -56,6 +56,19 @@ ruleTester.run("font-family-fallbacks", rule, {
 				},
 			},
 		},
+		"a { font-family: Serif; }",
+		"a { font-family: SANS-SERIF; }",
+		"a { font-family: Arial, Sans-Serif; }",
+		"a { font-family: 'Arial', 'Segoe UI Emoji', SERIF; }",
+		"a { font: 16px MONOSPACE; }",
+		"a { font: 16px Arial, MONOSPACE; }",
+		"a { font: italic bold 1.2em 'Open Sans', Sans-Serif; }",
+		":root { --my-font: SANS-SERIF; } a { font-family: var(--my-font); }",
+		":root { --my-font: 'Arial'; } a { font-family: var(--my-font), Sans-Serif; }",
+		"a { font: var(--font-size) 'Open Sans', MONOSPACE; }",
+		":root { --my-font: Arial, SANS-SERIF; } a { font: 16px/1.5 Helvetica, var(--my-font); }",
+		"a { font: 16px/1.5 Arial, var(--x), SANS-SERIF; }",
+		"a { font: var(--font-weight) var(--font-size)/var(--line-height) MONOSPACE; }",
 	],
 	invalid: [
 		{
@@ -271,6 +284,126 @@ ruleTester.run("font-family-fallbacks", rule, {
 					column: 59,
 					endLine: 1,
 					endColumn: 132,
+				},
+			],
+		},
+		{
+			code: 'a { font-family: Arial, "serif"; }',
+			errors: [
+				{
+					messageId: "useGenericFont",
+					line: 1,
+					column: 18,
+					endLine: 1,
+					endColumn: 32,
+				},
+			],
+		},
+		{
+			code: 'a { font-family: Arial, "SERIF"; }',
+			errors: [
+				{
+					messageId: "useGenericFont",
+					line: 1,
+					column: 18,
+					endLine: 1,
+					endColumn: 32,
+				},
+			],
+		},
+		{
+			code: 'a { font: 16px "SERIF"; }',
+			errors: [
+				{
+					messageId: "useFallbackFonts",
+					line: 1,
+					column: 11,
+					endLine: 1,
+					endColumn: 23,
+				},
+			],
+		},
+		{
+			code: 'a { font: 16px "MySerifFont"; }',
+			errors: [
+				{
+					messageId: "useFallbackFonts",
+					line: 1,
+					column: 11,
+					endLine: 1,
+					endColumn: 29,
+				},
+			],
+		},
+		{
+			code: 'a { font: 16px "serif"; }',
+			errors: [
+				{
+					messageId: "useFallbackFonts",
+					line: 1,
+					column: 11,
+					endLine: 1,
+					endColumn: 23,
+				},
+			],
+		},
+		{
+			code: "a { font: 16px MySerifFont; }",
+			errors: [
+				{
+					messageId: "useFallbackFonts",
+					line: 1,
+					column: 11,
+					endLine: 1,
+					endColumn: 27,
+				},
+			],
+		},
+		{
+			code: "a { font: 16px MyserifFont; }",
+			errors: [
+				{
+					messageId: "useFallbackFonts",
+					line: 1,
+					column: 11,
+					endLine: 1,
+					endColumn: 27,
+				},
+			],
+		},
+		{
+			code: "a { font: 16px MYSERIFFONT; }",
+			errors: [
+				{
+					messageId: "useFallbackFonts",
+					line: 1,
+					column: 11,
+					endLine: 1,
+					endColumn: 27,
+				},
+			],
+		},
+		{
+			code: "a { font: 16px MyMonospaceFont; }",
+			errors: [
+				{
+					messageId: "useFallbackFonts",
+					line: 1,
+					column: 11,
+					endLine: 1,
+					endColumn: 31,
+				},
+			],
+		},
+		{
+			code: ":root { --my-font: 'Arial'; } a { font-family: var(--my-font), \"sans-serif\"; }",
+			errors: [
+				{
+					messageId: "useGenericFont",
+					line: 1,
+					column: 48,
+					endLine: 1,
+					endColumn: 76,
 				},
 			],
 		},

--- a/tests/rules/font-family-fallbacks.test.js
+++ b/tests/rules/font-family-fallbacks.test.js
@@ -407,5 +407,53 @@ ruleTester.run("font-family-fallbacks", rule, {
 				},
 			],
 		},
+		{
+			code: "a { font: 16px 'Roboto', 'Open Sans', 'serif'; }",
+			errors: [
+				{
+					messageId: "useGenericFont",
+					line: 1,
+					column: 11,
+					endLine: 1,
+					endColumn: 46,
+				},
+			],
+		},
+		{
+			code: ":root { --my-font: 'serif'; } a { font: 16px var(--my-font); }",
+			errors: [
+				{
+					messageId: "useFallbackFonts",
+					line: 1,
+					column: 41,
+					endLine: 1,
+					endColumn: 60,
+				},
+			],
+		},
+		{
+			code: ":root { --my-font: 'MySerifFont'; } a { font: 16px var(--my-font); }",
+			errors: [
+				{
+					messageId: "useFallbackFonts",
+					line: 1,
+					column: 47,
+					endLine: 1,
+					endColumn: 66,
+				},
+			],
+		},
+		{
+			code: ":root { --my-font: 'Roboto', 'Open Sans', 'serif'; } a { font: 16px var(--my-font); }",
+			errors: [
+				{
+					messageId: "useGenericFont",
+					line: 1,
+					column: 64,
+					endLine: 1,
+					endColumn: 83,
+				},
+			],
+		},
 	],
 });


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

Bug fix.

> [!NOTE]
> This also removes some false negatives, so the rule reports more errors in the three cases listed under "Side effects" below. Per the [versioning policy](https://github.com/eslint/eslint#semantic-versioning-policy), this belongs in a minor release rather than a patch, so it may belong under `feat` rather than `fix`.

#### What changes did you make? (Give an overview)

Generic font families are CSS keywords, so they are matched ASCII case-insensitively, but the rule compared candidates against a lowercase set without normalizing them. `Sans-Serif`, `SERIF` and `MONOSPACE` were reported even though they are valid.

The rule consults the generic font list in eleven places, covering the `font-family` property, the `font` shorthand, and the paths that resolve `var()` references. Ten of them are direct `genericFonts.has()` lookups. The eleventh is a substring match in the single value `font` branch, where the family name is not separated from the rest of the value.

I added an `isGenericFont()` helper that lowercases before the lookup and used it at the ten direct lookups, so the behaviour is consistent across paths rather than fixed only in the ones the issue happened to demonstrate.

Two places needed more than lowercasing, because they cannot tell a keyword from a family name on their own:

- **The single value `font` branch**, the eleventh site above. Since it scans the whole value, lowercasing alone would make `font: 16px "SERIF"` and `font: 16px MySerifFont` pass silently. It now removes quoted names first and requires a whole word match.
- **The list the `var()` path compares against.** It is built from `String` node values, which arrive with their quotes already stripped, mixed together with identifier names. The lookup itself is one of the ten, but lowercasing it alone would make `font-family: var(--f), "SANS-SERIF"` pass silently, so the list now keeps the original text.

That leaves two mechanisms for the same concept, which is worth explaining. The comparisons take two shapes. The ten direct lookups each receive a single token, so an exact match after lowercasing is enough, and that is what `isGenericFont()` does. The single value `font` branch receives the whole shorthand with the size still attached, so it has to search inside a string, and that search needs a word boundary. `genericFontPattern` is compiled once at module load rather than per call, and it carries no `g` flag, so there is no `lastIndex` state to worry about.

`docs/rules/font-family-fallbacks.md` is unchanged, since nothing in it describes this behaviour.

#### Side effects worth calling out

Telling keywords and family names apart in those two places means three kinds of input that were previously accepted are now reported. None of these relax the rule, and all of them are cases where there is genuinely no generic fallback:

- `font: 16px "serif"`. A quoted name in the single value `font` branch was being read as a generic keyword.
- `font-family: var(--f), "sans-serif"`. The same confusion through the `var()` path. These two are the distinction you asked me to cover with an invalid test case.
- `font: 16px MyserifFont`. The single value `font` branch matches by substring, so an unquoted family name that contains a generic keyword was accepted. Without a word boundary, lowercasing would also have let `MYSERIFFONT` through, so this one is not separable from the fix.

To check that nothing else moved, I swept the rule with a generated matrix of inputs covering every generic keyword through each of these branches and compared the output before and after. Every behaviour change falls into the three cases above, and there was no fourth category. (129 inputs became accepted, which is the intended fix, and 53 became reported, all of them instances of the three cases.)

#### Tests

- Valid cases for uppercase spellings, one per code path, so each of the ten direct lookups is covered.
- Invalid cases for quoted generic names, which is what you asked for: in `font-family`, in the `font` shorthand, and through a `var()` reference.
- Invalid cases for family names that contain a generic keyword as a substring, such as `MySerifFont` and `MyMonospaceFont`.

To confirm the new tests actually guard the change I ran it three ways.

Running the rule's own test file, `npx mocha tests/rules/font-family-fallbacks.test.js`:

| Source | Result |
| --- | --- |
| unchanged | 64 passing, 16 failing |
| lowercasing only, without the two special cases | 72 passing, 8 failing |
| this PR | 80 passing |

The middle row is the useful one. The quoted and substring tests are what catch a naive fix, and you can reproduce it on this branch by reverting the two special cases.

<img width="600" alt="8 failing" src="https://github.com/user-attachments/assets/ebce0572-0cb0-4867-a0a1-b387d52d4df1" />

(This is not the state of this PR. It shows what fails if the fix is done with lowercasing alone, without the two special cases described above.)

`npm test` and `npm run lint` both pass.

#### Related Issues

fixes #516

#### Is there anything you'd like reviewers to focus on?

The whole word match in the single value `font` branch. It is the one place where I changed how matching works rather than only normalizing case, and it is where the third side effect comes from.

If you would prefer a narrower change, the way to narrow it is to leave that branch untouched entirely. Dropping only the word boundary is not an option, because lowercasing without it lets `MYSERIFFONT` through, which would be a regression. Leaving the branch alone would keep `font: 16px SERIF` broken while the other paths are fixed, so I would rather include it, but I can split it out if you disagree.
