### PR TITLE
chore: add allowScripts for yorkie

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
   "gitHooks": {
     "pre-commit": "lint-staged"
   },
+  "allowScripts": {
+    "yorkie": true
+  },
   "lint-staged": {
     "*.js": [
       "eslint --fix",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

Starting from npm 11.16.0, a warning appears when there's an install script that isn't listed in `allowScripts`:

```
npm warn allow-scripts 1 package has install scripts not yet covered by allowScripts:
npm warn allow-scripts   yorkie@2.0.0 (install: (install scripts present))
```

#### What changes did you make? (Give an overview)

Added the `allowScripts` field to `package.json` to allow yorkie.

Tested with npm 11.16.0 and confirmed that the warning appeared before this change, and that after the change, the `prepare` script (build) and pre-commit hook worked correctly without any warning.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
