### PR TITLE
test: add error location assertion for relative-font-units

### DIFF
--- a/tests/rules/relative-font-units.test.js
+++ b/tests/rules/relative-font-units.test.js
@@ -337,6 +337,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 19,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -346,6 +350,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 19,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -360,6 +368,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 20,
 					data: { allowedFontUnits: "em" },
 				},
 			],
@@ -374,6 +386,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 19,
 					data: { allowedFontUnits: "em" },
 				},
 			],
@@ -388,6 +404,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 19,
 					data: { allowedFontUnits: "%" },
 				},
 			],
@@ -402,6 +422,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 20,
 					data: { allowedFontUnits: "cap" },
 				},
 			],
@@ -416,6 +440,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 20,
 					data: { allowedFontUnits: "ch" },
 				},
 			],
@@ -430,6 +458,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 20,
 					data: { allowedFontUnits: "ex" },
 				},
 			],
@@ -444,6 +476,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 20,
 					data: { allowedFontUnits: "ic" },
 				},
 			],
@@ -458,6 +494,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 19,
 					data: { allowedFontUnits: "em" },
 				},
 			],
@@ -472,6 +512,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 20,
 					data: { allowedFontUnits: "lh" },
 				},
 			],
@@ -486,6 +530,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 19,
 					data: { allowedFontUnits: "rcap" },
 				},
 			],
@@ -500,6 +548,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 19,
 					data: { allowedFontUnits: "rch" },
 				},
 			],
@@ -514,6 +566,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 19,
 					data: { allowedFontUnits: "rex" },
 				},
 			],
@@ -528,6 +584,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 20,
 					data: { allowedFontUnits: "ric" },
 				},
 			],
@@ -542,6 +602,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 19,
 					data: { allowedFontUnits: "rlh" },
 				},
 			],
@@ -563,6 +627,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 2,
+					column: 16,
+					endLine: 2,
+					endColumn: 20,
 					data: { allowedFontUnits: "em" },
 				},
 			],
@@ -582,6 +650,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 2,
+					column: 16,
+					endLine: 2,
+					endColumn: 20,
 					data: { allowedFontUnits: "em" },
 				},
 			],
@@ -591,6 +663,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 19,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -600,6 +676,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 19,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -609,6 +689,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 19,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -618,6 +702,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 19,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -627,6 +715,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 19,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -636,6 +728,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 19,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -646,6 +742,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 19,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -656,6 +756,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 11,
+					endLine: 1,
+					endColumn: 14,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -665,6 +769,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 24,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -674,6 +782,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 11,
+					endLine: 1,
+					endColumn: 19,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -683,6 +795,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 23,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -692,6 +808,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 11,
+					endLine: 1,
+					endColumn: 18,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -701,6 +821,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 21,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -710,6 +834,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 11,
+					endLine: 1,
+					endColumn: 16,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -719,6 +847,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 22,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -728,6 +860,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 11,
+					endLine: 1,
+					endColumn: 17,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -737,6 +873,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 21,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -746,6 +886,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 11,
+					endLine: 1,
+					endColumn: 16,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -755,6 +899,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 23,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -764,6 +912,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 11,
+					endLine: 1,
+					endColumn: 18,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -773,6 +925,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 24,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -782,6 +938,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 11,
+					endLine: 1,
+					endColumn: 19,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -791,6 +951,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 25,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -800,6 +964,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 11,
+					endLine: 1,
+					endColumn: 20,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -809,6 +977,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 20,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -818,6 +990,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 11,
+					endLine: 1,
+					endColumn: 15,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -836,6 +1012,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 2,
+					column: 11,
+					endLine: 2,
+					endColumn: 15,
 					data: { allowedFontUnits: "em" },
 				},
 			],
@@ -854,6 +1034,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 2,
+					column: 11,
+					endLine: 2,
+					endColumn: 14,
 					data: { allowedFontUnits: "em" },
 				},
 			],
@@ -872,6 +1056,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 2,
+					column: 11,
+					endLine: 2,
+					endColumn: 15,
 					data: { allowedFontUnits: "em" },
 				},
 			],
@@ -890,6 +1078,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 2,
+					column: 11,
+					endLine: 2,
+					endColumn: 14,
 					data: { allowedFontUnits: "%" },
 				},
 			],
@@ -908,6 +1100,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 2,
+					column: 11,
+					endLine: 2,
+					endColumn: 16,
 					data: { allowedFontUnits: "%" },
 				},
 			],
@@ -926,6 +1122,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 2,
+					column: 16,
+					endLine: 2,
+					endColumn: 20,
 					data: { allowedFontUnits: "%, em" },
 				},
 			],
@@ -947,6 +1147,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 5,
+					column: 16,
+					endLine: 5,
+					endColumn: 19,
 					data: { allowedFontUnits: "rem, rex" },
 				},
 			],
@@ -969,6 +1173,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 6,
+					column: 16,
+					endLine: 6,
+					endColumn: 19,
 					data: { allowedFontUnits: "rem, rex, %" },
 				},
 			],
@@ -987,6 +1195,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 2,
+					column: 23,
+					endLine: 2,
+					endColumn: 27,
 					data: { allowedFontUnits: "lh, rex, %" },
 				},
 			],
@@ -1000,6 +1212,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 2,
+					column: 23,
+					endLine: 2,
+					endColumn: 28,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -1013,6 +1229,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 2,
+					column: 38,
+					endLine: 2,
+					endColumn: 43,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -1026,6 +1246,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 2,
+					column: 43,
+					endLine: 2,
+					endColumn: 47,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -1040,6 +1264,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 3,
+					column: 16,
+					endLine: 3,
+					endColumn: 20,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -1049,6 +1277,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 24,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -1058,6 +1290,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 11,
+					endLine: 1,
+					endColumn: 19,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -1067,6 +1303,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 23,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -1076,6 +1316,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 11,
+					endLine: 1,
+					endColumn: 18,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -1085,6 +1329,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 21,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -1094,6 +1342,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 11,
+					endLine: 1,
+					endColumn: 16,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -1103,6 +1355,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 22,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -1112,6 +1368,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 11,
+					endLine: 1,
+					endColumn: 17,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -1121,6 +1381,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 21,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -1130,6 +1394,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 11,
+					endLine: 1,
+					endColumn: 16,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -1139,6 +1407,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 23,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -1148,6 +1420,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 11,
+					endLine: 1,
+					endColumn: 18,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -1157,6 +1433,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 24,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -1166,6 +1446,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 11,
+					endLine: 1,
+					endColumn: 19,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -1175,6 +1459,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 25,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -1184,6 +1472,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 11,
+					endLine: 1,
+					endColumn: 20,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -1193,6 +1485,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 20,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -1202,6 +1498,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 11,
+					endLine: 1,
+					endColumn: 15,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -1211,6 +1511,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 24,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -1220,6 +1524,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 11,
+					endLine: 1,
+					endColumn: 19,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -1229,6 +1537,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 23,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -1238,6 +1550,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 11,
+					endLine: 1,
+					endColumn: 18,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -1247,6 +1563,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 21,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -1256,6 +1576,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 11,
+					endLine: 1,
+					endColumn: 16,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -1265,6 +1589,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 18,
+					endLine: 1,
+					endColumn: 23,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -1274,6 +1602,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 22,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -1283,6 +1615,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 11,
+					endLine: 1,
+					endColumn: 17,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -1292,6 +1628,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 21,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -1301,6 +1641,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 11,
+					endLine: 1,
+					endColumn: 16,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -1310,6 +1654,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 23,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -1319,6 +1667,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 11,
+					endLine: 1,
+					endColumn: 18,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -1328,6 +1680,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 24,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -1337,6 +1693,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 11,
+					endLine: 1,
+					endColumn: 19,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -1346,6 +1706,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 25,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -1355,6 +1719,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 11,
+					endLine: 1,
+					endColumn: 20,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -1364,6 +1732,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 20,
 					data: { allowedFontUnits: "rem" },
 				},
 			],
@@ -1373,6 +1745,10 @@ ruleTester.run("relative-font-units", rule, {
 			errors: [
 				{
 					messageId: "allowedFontUnits",
+					line: 1,
+					column: 11,
+					endLine: 1,
+					endColumn: 15,
 					data: { allowedFontUnits: "rem" },
 				},
 			],


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

Adds location assertions to the `relative-font-units` rule tests to ensure errors are reported at the correct source locations.

#### What changes did you make? (Give an overview)


Added `line`, `column`, `endLine`, and `endColumn` assertions to invalid test cases for the `relative-font-units` rule.


#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

Refs eslint/eslint#21102


#### Is there anything you'd like reviewers to focus on?
