### PR TITLE
feat: check duplicate comma-separated @keyframe selectors

### DIFF
--- a/docs/rules/no-duplicate-keyframe-selectors.md
+++ b/docs/rules/no-duplicate-keyframe-selectors.md
@@ -40,6 +40,17 @@ Examples of **incorrect** code for this rule:
 }
 
 @keyframes test {
+	0%,
+	50% {
+		opacity: 0;
+	}
+
+	50% {
+		opacity: 1;
+	}
+}
+
+@keyframes test {
 	from {
 		opacity: 0;
 	}
@@ -90,6 +101,21 @@ Examples of **correct** code for this rule:
 @keyframes test {
 	0% {
 		opacity: 0;
+	}
+
+	100% {
+		opacity: 1;
+	}
+}
+
+@keyframes test {
+	0% {
+		opacity: 0;
+	}
+
+	30%,
+	60% {
+		opacity: 0.5;
 	}
 
 	100% {

--- a/src/rules/no-duplicate-keyframe-selectors.js
+++ b/src/rules/no-duplicate-keyframe-selectors.js
@@ -62,51 +62,32 @@ export default /** @satisfies {DuplicateKeyframeSelectorRuleDefinition} */ ({
 				}
 
 				// @ts-ignore - children is a valid property for prelude
-				const selectors = node.prelude.children;
-				const value = [];
+				node.prelude.children.forEach(selector => {
+					const value = [];
 
-				selectors.forEach(selector => {
-					const component = selector.children[0];
-					const componentType = component.type;
-
-					if (selector.children.length === 1) {
-						if (componentType === "Percentage") {
+					selector.children.forEach(component => {
+						if (component.type === "Percentage") {
 							value.push(`${component.value}%`);
-						} else if (componentType === "TypeSelector") {
+						} else if (component.type === "TypeSelector") {
 							value.push(component.name.toLowerCase());
 						}
-					} else {
-						if (
-							selector.children.some(
-								child => child.type === "Combinator",
-							)
-						) {
-							if (
-								componentType === "TypeSelector" &&
-								selector.children[1].type === "Combinator" &&
-								selector.children[2].type === "Percentage"
-							) {
-								value.push(
-									`${component.name.toLowerCase()} ${selector.children[2].value}%`,
-								);
-							}
-						}
-					}
-				});
+					});
 
-				const keys = value.map(
-					selectorPart =>
-						keyframeSelectorAliases.get(selectorPart) ??
-						selectorPart,
-				);
+					const selectorValue = value.join(" ");
+					const key = value
+						.map(
+							selectorPart =>
+								keyframeSelectorAliases.get(selectorPart) ??
+								selectorPart,
+						)
+						.join(" ");
 
-				keys.forEach((key, i) => {
 					if (seen.has(key)) {
 						context.report({
-							loc: selectors[i].loc,
+							loc: selector.loc,
 							messageId: "duplicateKeyframeSelector",
 							data: {
-								selector: value[i],
+								selector: selectorValue,
 							},
 						});
 					} else {

--- a/src/rules/no-duplicate-keyframe-selectors.js
+++ b/src/rules/no-duplicate-keyframe-selectors.js
@@ -62,37 +62,57 @@ export default /** @satisfies {DuplicateKeyframeSelectorRuleDefinition} */ ({
 				}
 
 				// @ts-ignore - children is a valid property for prelude
-				const selector = node.prelude.children[0];
+				const selectors = node.prelude.children;
 				const value = [];
 
-				selector.children.forEach(component => {
-					if (component.type === "Percentage") {
-						value.push(`${component.value}%`);
-					} else if (component.type === "TypeSelector") {
-						value.push(component.name.toLowerCase());
+				selectors.forEach(selector => {
+					const component = selector.children[0];
+					const componentType = component.type;
+
+					if (selector.children.length === 1) {
+						if (componentType === "Percentage") {
+							value.push(`${component.value}%`);
+						} else if (componentType === "TypeSelector") {
+							value.push(component.name.toLowerCase());
+						}
+					} else {
+						if (
+							selector.children.some(
+								child => child.type === "Combinator",
+							)
+						) {
+							if (
+								componentType === "TypeSelector" &&
+								selector.children[1].type === "Combinator" &&
+								selector.children[2].type === "Percentage"
+							) {
+								value.push(
+									`${component.name.toLowerCase()} ${selector.children[2].value}%`,
+								);
+							}
+						}
 					}
 				});
 
-				const selectorValue = value.join(" ");
-				const key = value
-					.map(
-						selectorPart =>
-							keyframeSelectorAliases.get(selectorPart) ??
-							selectorPart,
-					)
-					.join(" ");
+				const keys = value.map(
+					selectorPart =>
+						keyframeSelectorAliases.get(selectorPart) ??
+						selectorPart,
+				);
 
-				if (seen.has(key)) {
-					context.report({
-						loc: selector.loc,
-						messageId: "duplicateKeyframeSelector",
-						data: {
-							selector: selectorValue,
-						},
-					});
-				} else {
-					seen.add(key);
-				}
+				keys.forEach((key, i) => {
+					if (seen.has(key)) {
+						context.report({
+							loc: selectors[i].loc,
+							messageId: "duplicateKeyframeSelector",
+							data: {
+								selector: value[i],
+							},
+						});
+					} else {
+						seen.add(key);
+					}
+				});
 			},
 		};
 	},

--- a/tests/rules/no-duplicate-keyframe-selectors.test.js
+++ b/tests/rules/no-duplicate-keyframe-selectors.test.js
@@ -56,6 +56,10 @@ ruleTester.run("no-duplicate-keyframe-selectors", rule, {
             100% { opacity: 1; }
         }`,
 		dedent`@keyframes test {
+            0%, 10%, 20% { opacity: 0; }
+            50%, 100% { opacity: 1; }
+        }`,
+		dedent`@keyframes test {
             from { opacity: 0; }
             50% { opacity: 0.5; }
             to { opacity: 1; }
@@ -422,6 +426,22 @@ ruleTester.run("no-duplicate-keyframe-selectors", rule, {
 		},
 		{
 			code: dedent`@KEYFRAMES test {
+                0%, 50% { opacity: 0; }
+                70%, 100%, 0% { opacity: 1; }
+            }`,
+			errors: [
+				{
+					messageId: "duplicateKeyframeSelector",
+					data: { selector: "0%" },
+					line: 3,
+					column: 16,
+					endLine: 3,
+					endColumn: 18,
+				},
+			],
+		},
+		{
+			code: dedent`@KEYFRAMES test {
                 0%, 0% { top: 0; }
             }`,
 			errors: [
@@ -583,6 +603,22 @@ ruleTester.run("no-duplicate-keyframe-selectors", rule, {
 		},
 		{
 			code: dedent`@keyframes test {
+                entry 0% { opacity: 0; }
+                50%, 100%, entry 0% { opacity: 1; }
+            }`,
+			errors: [
+				{
+					messageId: "duplicateKeyframeSelector",
+					data: { selector: "entry 0%" },
+					line: 3,
+					column: 16,
+					endLine: 3,
+					endColumn: 24,
+				},
+			],
+		},
+		{
+			code: dedent`@keyframes test {
                 entry 0%, Entry 0% { opacity: 0; }
             }`,
 			errors: [
@@ -609,6 +645,22 @@ ruleTester.run("no-duplicate-keyframe-selectors", rule, {
 					column: 5,
 					endLine: 3,
 					endColumn: 14,
+				},
+			],
+		},
+		{
+			code: dedent`@keyframes test {
+                entry 0%, exit 100% { opacity: 0; }
+                50%, 100%, exit 100% { opacity: 1; }
+            }`,
+			errors: [
+				{
+					messageId: "duplicateKeyframeSelector",
+					data: { selector: "exit 100%" },
+					line: 3,
+					column: 16,
+					endLine: 3,
+					endColumn: 25,
 				},
 			],
 		},
@@ -755,6 +807,22 @@ ruleTester.run("no-duplicate-keyframe-selectors", rule, {
 		{
 			code: dedent`@keyframes test {
                 from { opacity: 0; }
+                50%, 100%, 0% { opacity: 1; }
+            }`,
+			errors: [
+				{
+					messageId: "duplicateKeyframeSelector",
+					data: { selector: "0%" },
+					line: 3,
+					column: 16,
+					endLine: 3,
+					endColumn: 18,
+				},
+			],
+		},
+		{
+			code: dedent`@keyframes test {
+                from { opacity: 0; }
                 to, 100% { opacity: 1; }
             }`,
 			errors: [
@@ -797,6 +865,22 @@ ruleTester.run("no-duplicate-keyframe-selectors", rule, {
 					column: 11,
 					endLine: 3,
 					endColumn: 13,
+				},
+			],
+		},
+		{
+			code: dedent`@keyframes test {
+                from { opacity: 0; }
+                50%, 100%, to { opacity: 1; }
+            }`,
+			errors: [
+				{
+					messageId: "duplicateKeyframeSelector",
+					data: { selector: "to" },
+					line: 3,
+					column: 16,
+					endLine: 3,
+					endColumn: 18,
 				},
 			],
 		},

--- a/tests/rules/no-duplicate-keyframe-selectors.test.js
+++ b/tests/rules/no-duplicate-keyframe-selectors.test.js
@@ -51,7 +51,17 @@ ruleTester.run("no-duplicate-keyframe-selectors", rule, {
             100% { opacity: 1; }
         }`,
 		dedent`@keyframes test {
+            0%, 20% { opacity: 0; }
+            50% { opacity: 0.5; }
+            100% { opacity: 1; }
+        }`,
+		dedent`@keyframes test {
             from { opacity: 0; }
+            50% { opacity: 0.5; }
+            to { opacity: 1; }
+        }`,
+		dedent`@keyframes test {
+            from, 30% { opacity: 0; }
             50% { opacity: 0.5; }
             to { opacity: 1; }
         }`,
@@ -82,6 +92,16 @@ ruleTester.run("no-duplicate-keyframe-selectors", rule, {
             entry 100% { opacity: 1; }
             exit 0% { opacity: 1; }
             exit 100% { opacity: 0; }
+        }`,
+		dedent`@keyframes test {
+            entry 0%, 30% { opacity: 0; }
+            entry 100% { opacity: 1; }
+            exit 0%, 50% { opacity: 1; }
+            exit 100% { opacity: 0; }
+        }`,
+		dedent`@keyframes test {
+            entry 0%, 0% { opacity: 0; }
+            exit 100%, 100% { opacity: 1; }
         }`,
 	],
 	invalid: [
@@ -353,6 +373,69 @@ ruleTester.run("no-duplicate-keyframe-selectors", rule, {
 			],
 		},
 		{
+			code: dedent`@KEYFRAMES test {
+                0% { opacity: 0; }
+                0%, 50% { opacity: 1; }
+            }`,
+			errors: [
+				{
+					messageId: "duplicateKeyframeSelector",
+					data: { selector: "0%" },
+					line: 3,
+					column: 5,
+					endLine: 3,
+					endColumn: 7,
+				},
+			],
+		},
+		{
+			code: dedent`@KEYFRAMES test {
+                0%, 50% { opacity: 0; }
+                50% { opacity: 1; }
+            }`,
+			errors: [
+				{
+					messageId: "duplicateKeyframeSelector",
+					data: { selector: "50%" },
+					line: 3,
+					column: 5,
+					endLine: 3,
+					endColumn: 8,
+				},
+			],
+		},
+		{
+			code: dedent`@KEYFRAMES test {
+                50% { opacity: 0; }
+                0%, 50% { opacity: 1; }
+            }`,
+			errors: [
+				{
+					messageId: "duplicateKeyframeSelector",
+					data: { selector: "50%" },
+					line: 3,
+					column: 9,
+					endLine: 3,
+					endColumn: 12,
+				},
+			],
+		},
+		{
+			code: dedent`@KEYFRAMES test {
+                0%, 0% { top: 0; }
+            }`,
+			errors: [
+				{
+					messageId: "duplicateKeyframeSelector",
+					data: { selector: "0%" },
+					line: 2,
+					column: 9,
+					endLine: 2,
+					endColumn: 11,
+				},
+			],
+		},
+		{
 			code: dedent`@Keyframes test {
                 0% {
                     opacity: 0;
@@ -468,6 +551,85 @@ ruleTester.run("no-duplicate-keyframe-selectors", rule, {
 		},
 		{
 			code: dedent`@keyframes test {
+                entry 0% { opacity: 0; }
+                entry 0%, 50% { opacity: 1; }
+            }`,
+			errors: [
+				{
+					messageId: "duplicateKeyframeSelector",
+					data: { selector: "entry 0%" },
+					line: 3,
+					column: 5,
+					endLine: 3,
+					endColumn: 13,
+				},
+			],
+		},
+		{
+			code: dedent`@keyframes test {
+                entry 0% { opacity: 0; }
+                50%, entry 0% { opacity: 1; }
+            }`,
+			errors: [
+				{
+					messageId: "duplicateKeyframeSelector",
+					data: { selector: "entry 0%" },
+					line: 3,
+					column: 10,
+					endLine: 3,
+					endColumn: 18,
+				},
+			],
+		},
+		{
+			code: dedent`@keyframes test {
+                entry 0%, Entry 0% { opacity: 0; }
+            }`,
+			errors: [
+				{
+					messageId: "duplicateKeyframeSelector",
+					data: { selector: "entry 0%" },
+					line: 2,
+					column: 15,
+					endLine: 2,
+					endColumn: 23,
+				},
+			],
+		},
+		{
+			code: dedent`@keyframes test {
+                entry 0%, exit 100% { opacity: 0; }
+                exit 100% { opacity: 1; }
+            }`,
+			errors: [
+				{
+					messageId: "duplicateKeyframeSelector",
+					data: { selector: "exit 100%" },
+					line: 3,
+					column: 5,
+					endLine: 3,
+					endColumn: 14,
+				},
+			],
+		},
+		{
+			code: dedent`@keyframes test {
+                entry 0%, Exit 100% { opacity: 0; }
+                exit 100% { opacity: 1; }
+            }`,
+			errors: [
+				{
+					messageId: "duplicateKeyframeSelector",
+					data: { selector: "exit 100%" },
+					line: 3,
+					column: 5,
+					endLine: 3,
+					endColumn: 14,
+				},
+			],
+		},
+		{
+			code: dedent`@keyframes test {
 			    from { opacity: 0; }
 			    0% { opacity: 0.25; }
 			    to { opacity: 1; }
@@ -541,6 +703,100 @@ ruleTester.run("no-duplicate-keyframe-selectors", rule, {
 					column: 5,
 					endLine: 5,
 					endColumn: 7,
+				},
+			],
+		},
+		{
+			code: dedent`@keyframes test {
+                from, 0% { opacity: 0; }
+            }`,
+			errors: [
+				{
+					messageId: "duplicateKeyframeSelector",
+					data: { selector: "0%" },
+					line: 2,
+					column: 11,
+					endLine: 2,
+					endColumn: 13,
+				},
+			],
+		},
+		{
+			code: dedent`@keyframes test {
+                0%, from { opacity: 0; }
+            }`,
+			errors: [
+				{
+					messageId: "duplicateKeyframeSelector",
+					data: { selector: "from" },
+					line: 2,
+					column: 9,
+					endLine: 2,
+					endColumn: 13,
+				},
+			],
+		},
+		{
+			code: dedent`@keyframes test {
+                from { opacity: 0; }
+                0%, 50% { opacity: 1; }
+            }`,
+			errors: [
+				{
+					messageId: "duplicateKeyframeSelector",
+					data: { selector: "0%" },
+					line: 3,
+					column: 5,
+					endLine: 3,
+					endColumn: 7,
+				},
+			],
+		},
+		{
+			code: dedent`@keyframes test {
+                from { opacity: 0; }
+                to, 100% { opacity: 1; }
+            }`,
+			errors: [
+				{
+					messageId: "duplicateKeyframeSelector",
+					data: { selector: "100%" },
+					line: 3,
+					column: 9,
+					endLine: 3,
+					endColumn: 13,
+				},
+			],
+		},
+		{
+			code: dedent`@keyframes test {
+                from, 100% { opacity: 0; }
+                to { opacity: 1; }
+            }`,
+			errors: [
+				{
+					messageId: "duplicateKeyframeSelector",
+					data: { selector: "to" },
+					line: 3,
+					column: 5,
+					endLine: 3,
+					endColumn: 7,
+				},
+			],
+		},
+		{
+			code: dedent`@keyframes test {
+                from { opacity: 0; }
+                100%, to { opacity: 1; }
+            }`,
+			errors: [
+				{
+					messageId: "duplicateKeyframeSelector",
+					data: { selector: "to" },
+					line: 3,
+					column: 11,
+					endLine: 3,
+					endColumn: 13,
 				},
 			],
 		},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?
To also check the duplicate @keyframe selectors that are comma-separated.

#### What changes did you make? (Give an overview)
Added a loop to go through every selector in a rule instead of just the first one to enable checking comma-separated selectors as duplicates, and added related test cases also. Now rule `no-duplicate-keyframe-selectors` will also report cases such as:

```css
@keyframes a {
	0%, 50% { top: 0; }
	50% { top: 1px; }
}

@keyframes a {
	from, 0% { top: 0; }
	50% { top: 1px; }
}

@keyframes a {
	entry 0%, { top: 0; }
	entry 0%, 50% { top: 1px; }
}
```

#### Related Issues
Fixes #459

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
