### PR TITLE
docs: fix subject-verb agreement in relative-font-units

### DIFF
--- a/docs/rules/relative-font-units.md
+++ b/docs/rules/relative-font-units.md
@@ -14,7 +14,7 @@ Generally, relative units such as `rem` or `em` are preferred over absolute ones
 
 - **Responsive Design** - Relative units adapt better to various screen widths and pixel densities (e.g., mobile vs. desktop).
 - **Accessibility** - Relative units allow text to scale when users adjust browser settings or zoom levels.
-- **Consistency and Scalability** - Using relative units allow for consistent scaling across a whole site.
+- **Consistency and Scalability** - Using relative units allows for consistent scaling across a whole site.
 - **Maintainability and Reusability** - Relative units allow components or utility classes to work well in different contexts.
 
 ## Rule Details


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

Fix a subject-verb agreement error in the `relative-font-units` documentation.

In the Background section of `docs/rules/relative-font-units.md`, I changed `Using relative units allow` to `Using relative units allows`.

 Disclosure: I'm a participant of [open source contribution program OSSCA](https://github.com/eslint-ossca)
 


