### PR TITLE
fix: handle CSS case-insensitivity

### DIFF
--- a/src/rules/font-family-fallbacks.js
+++ b/src/rules/font-family-fallbacks.js
@@ -82,7 +82,7 @@ function isCSSWideKeywordIdentifier(node, cssWideKeywords) {
  * @returns {boolean} True if the node is a variable function, false otherwise.
  */
 function isVarFunction(node) {
-	return node.type === "Function" && node.name === "var";
+	return node.type === "Function" && node.name.toLowerCase() === "var";
 }
 
 /**
@@ -167,7 +167,9 @@ export default /** @satisfies {FontFamilyFallbacksRuleDefinition} */ ({
 				}
 			},
 
-			"Rule > Block > Declaration[property='font-family'] > Value"(node) {
+			"Rule > Block > Declaration[property=/^font-family$/i] > Value"(
+				node,
+			) {
 				const valueArr = node.children;
 
 				if (valueArr.length === 1) {
@@ -177,10 +179,7 @@ export default /** @satisfies {FontFamilyFallbacksRuleDefinition} */ ({
 						return;
 					}
 
-					if (
-						valueArr[0].type === "Function" &&
-						valueArr[0].name === "var"
-					) {
+					if (isVarFunction(valueArr[0])) {
 						const variableName =
 							valueArr[0].children[0].type === "Identifier" &&
 							valueArr[0].children[0].name;
@@ -234,10 +233,7 @@ export default /** @satisfies {FontFamilyFallbacksRuleDefinition} */ ({
 						const fontsList = [];
 						const lastNode = valueArr.at(-1);
 
-						if (
-							lastNode.type === "Function" &&
-							lastNode.name === "var"
-						) {
+						if (isVarFunction(lastNode)) {
 							const variableName =
 								lastNode.children[0].type === "Identifier" &&
 								lastNode.children[0].name;
@@ -258,10 +254,7 @@ export default /** @satisfies {FontFamilyFallbacksRuleDefinition} */ ({
 								fontsList.push(child.name);
 							}
 
-							if (
-								child.type === "Function" &&
-								child.name === "var"
-							) {
+							if (isVarFunction(child)) {
 								const variableName =
 									child.children[0].type === "Identifier" &&
 									child.children[0].name;
@@ -302,7 +295,7 @@ export default /** @satisfies {FontFamilyFallbacksRuleDefinition} */ ({
 				}
 			},
 
-			"Rule > Block > Declaration[property='font'] > Value"(node) {
+			"Rule > Block > Declaration[property=/^font$/i] > Value"(node) {
 				const valueArr = node.children;
 
 				if (valueArr.length === 1) {
@@ -314,10 +307,7 @@ export default /** @satisfies {FontFamilyFallbacksRuleDefinition} */ ({
 					}
 
 					// If the value is a variable function, we need to check the variable value
-					if (
-						firstValue.type === "Function" &&
-						firstValue.name === "var"
-					) {
+					if (isVarFunction(firstValue)) {
 						// Check if the function is a variable
 						const variableName =
 							firstValue.children[0].type === "Identifier" &&
@@ -369,7 +359,7 @@ export default /** @satisfies {FontFamilyFallbacksRuleDefinition} */ ({
 
 							if (afterOperator.length !== 0) {
 								const usingVar = afterOperator.some(value =>
-									value.startsWith("var"),
+									value.toLowerCase().startsWith("var"),
 								);
 
 								if (!usingVar) {
@@ -381,12 +371,14 @@ export default /** @satisfies {FontFamilyFallbacksRuleDefinition} */ ({
 									}
 								} else {
 									if (
-										afterOperator.at(-1).startsWith("var")
+										afterOperator
+											.at(-1)
+											.toLowerCase()
+											.startsWith("var")
 									) {
 										const lastNode = valueArr.at(-1);
 										const isFunctionVar =
-											lastNode.type === "Function" &&
-											lastNode.name === "var";
+											isVarFunction(lastNode);
 										const variableName =
 											isFunctionVar &&
 											lastNode.children[0].type ===
@@ -429,12 +421,11 @@ export default /** @satisfies {FontFamilyFallbacksRuleDefinition} */ ({
 								sourceCode
 									.getText(valueArr.at(-1))
 									.trim()
+									.toLowerCase()
 									.startsWith("var")
 							) {
 								const lastNode = valueArr.at(-1);
-								const isFunctionVar =
-									lastNode.type === "Function" &&
-									lastNode.name === "var";
+								const isFunctionVar = isVarFunction(lastNode);
 								const variableName =
 									isFunctionVar &&
 									lastNode.children[0].type ===

--- a/src/rules/prefer-logical-properties.js
+++ b/src/rules/prefer-logical-properties.js
@@ -192,6 +192,12 @@ export default /** @satisfies {PreferLogicalPropertiesRuleDefinition} */ ({
 
 	create(context) {
 		const [{ allowProperties, allowUnits }] = context.options;
+		const allowedProperties = new Set(
+			allowProperties.map(property => property.toLowerCase()),
+		);
+		const allowedUnits = new Set(
+			allowUnits.map(unit => unit.toLowerCase()),
+		);
 
 		return {
 			Declaration(node) {
@@ -200,14 +206,11 @@ export default /** @satisfies {PreferLogicalPropertiesRuleDefinition} */ ({
 					return;
 				}
 
-				const propertyReplacement = propertiesReplacements.get(
-					node.property,
-				);
+				const property = node.property.toLowerCase();
+				const propertyReplacement =
+					propertiesReplacements.get(property);
 
-				if (
-					propertyReplacement &&
-					!allowProperties.includes(node.property)
-				) {
+				if (propertyReplacement && !allowedProperties.has(property)) {
 					context.report({
 						loc: node.loc,
 						messageId: "notLogicalProperty",
@@ -237,9 +240,8 @@ export default /** @satisfies {PreferLogicalPropertiesRuleDefinition} */ ({
 					});
 				}
 
-				const valueReplacements = propertyValuesReplacements.get(
-					node.property,
-				);
+				const valueReplacements =
+					propertyValuesReplacements.get(property);
 
 				if (
 					valueReplacements &&
@@ -248,7 +250,8 @@ export default /** @satisfies {PreferLogicalPropertiesRuleDefinition} */ ({
 				) {
 					const identifier = node.value.children[0];
 					const nodeValue = identifier.name;
-					const valueReplacement = valueReplacements[nodeValue];
+					const valueReplacement =
+						valueReplacements[nodeValue.toLowerCase()];
 
 					if (valueReplacement) {
 						context.report({
@@ -278,9 +281,10 @@ export default /** @satisfies {PreferLogicalPropertiesRuleDefinition} */ ({
 				}
 			},
 			Dimension(node) {
-				const unitReplacement = unitReplacements.get(node.unit);
+				const unit = node.unit.toLowerCase();
+				const unitReplacement = unitReplacements.get(unit);
 
-				if (unitReplacement && !allowUnits.includes(node.unit)) {
+				if (unitReplacement && !allowedUnits.has(unit)) {
 					context.report({
 						loc: node.loc,
 						messageId: "notLogicalUnit",

--- a/src/rules/prefer-logical-properties.js
+++ b/src/rules/prefer-logical-properties.js
@@ -192,12 +192,6 @@ export default /** @satisfies {PreferLogicalPropertiesRuleDefinition} */ ({
 
 	create(context) {
 		const [{ allowProperties, allowUnits }] = context.options;
-		const allowedProperties = new Set(
-			allowProperties.map(property => property.toLowerCase()),
-		);
-		const allowedUnits = new Set(
-			allowUnits.map(unit => unit.toLowerCase()),
-		);
 
 		return {
 			Declaration(node) {
@@ -210,7 +204,10 @@ export default /** @satisfies {PreferLogicalPropertiesRuleDefinition} */ ({
 				const propertyReplacement =
 					propertiesReplacements.get(property);
 
-				if (propertyReplacement && !allowedProperties.has(property)) {
+				if (
+					propertyReplacement &&
+					!allowProperties.includes(property)
+				) {
 					context.report({
 						loc: node.loc,
 						messageId: "notLogicalProperty",
@@ -284,7 +281,7 @@ export default /** @satisfies {PreferLogicalPropertiesRuleDefinition} */ ({
 				const unit = node.unit.toLowerCase();
 				const unitReplacement = unitReplacements.get(unit);
 
-				if (unitReplacement && !allowedUnits.has(unit)) {
+				if (unitReplacement && !allowUnits.includes(unit)) {
 					context.report({
 						loc: node.loc,
 						messageId: "notLogicalUnit",

--- a/src/rules/relative-font-units.js
+++ b/src/rules/relative-font-units.js
@@ -93,7 +93,9 @@ export default /** @satisfies {RelativeFontUnitsRuleDefinition} */ ({
 
 		return {
 			Declaration(node) {
-				if (node.property === "font-size") {
+				const property = node.property.toLowerCase();
+
+				if (property === "font-size") {
 					if (
 						node.value.type === "Value" &&
 						node.value.children.length > 0
@@ -124,7 +126,7 @@ export default /** @satisfies {RelativeFontUnitsRuleDefinition} */ ({
 					}
 				}
 
-				if (node.property === "font") {
+				if (property === "font") {
 					if (
 						node.value.type === "Value" &&
 						node.value.children.length > 0

--- a/src/rules/selector-complexity.js
+++ b/src/rules/selector-complexity.js
@@ -33,17 +33,6 @@
 //-----------------------------------------------------------------------------
 
 /**
- * Get the location of a selector of a given name.
- * @param {Array<Object>} allSelector All CSS selector nodes.
- * @param {string} disallowedSelector The name of the disallowed selector.
- * @returns {Object} The location of the disallowed selector.
- */
-function getDisallowedSelectorsLocation(allSelector, disallowedSelector) {
-	return allSelector.find(selector => selector.name === disallowedSelector)
-		.loc;
-}
-
-/**
  * An error for exceeding the maximum allowed selectors of a specific type.
  * @param {Object} context The ESLint rule context object.
  * @param {Object} selectorLoc The location of the selector.
@@ -282,6 +271,12 @@ export default /** @satisfies {SelectorComplexityRuleDefinition} */ ({
 				disallowAttributeMatchers,
 			},
 		] = context.options;
+		const disallowedPseudoClasses = new Set(
+			disallowPseudoClasses.map(selector => selector.toLowerCase()),
+		);
+		const disallowedPseudoElements = new Set(
+			disallowPseudoElements.map(selector => selector.toLowerCase()),
+		);
 
 		return {
 			Selector(node) {
@@ -309,14 +304,9 @@ export default /** @satisfies {SelectorComplexityRuleDefinition} */ ({
 				const combinatorNodes = getSelectors(selectors, "Combinator");
 
 				const combinators = getSelectorNames(combinatorNodes);
-				const pseudoClassSelectorsNames =
-					getSelectorNames(pseudoClassSelectors);
 				const pseudoElementSelectors = getSelectors(
 					selectors,
 					"PseudoElementSelector",
-				);
-				const pseudoElementNames = getSelectorNames(
-					pseudoElementSelectors,
 				);
 				const attributeNames = attributeSelectors.map(s => s.name.name);
 				const attributeMatchers = attributeSelectors
@@ -381,19 +371,17 @@ export default /** @satisfies {SelectorComplexityRuleDefinition} */ ({
 				}
 
 				if (disallowPseudoClasses.length > 0) {
-					let disallowedPseudoClassLocation;
-					for (const pseudoClassName of pseudoClassSelectorsNames) {
-						if (disallowPseudoClasses.includes(pseudoClassName)) {
-							disallowedPseudoClassLocation =
-								getDisallowedSelectorsLocation(
-									pseudoClassSelectors,
-									pseudoClassName,
-								);
+					for (const selectorNode of pseudoClassSelectors) {
+						if (
+							disallowedPseudoClasses.has(
+								selectorNode.name.toLowerCase(),
+							)
+						) {
 							context.report({
-								loc: disallowedPseudoClassLocation,
+								loc: selectorNode.loc,
 								messageId: "disallowedSelectors",
 								data: {
-									selectorName: pseudoClassName,
+									selectorName: selectorNode.name,
 									selector: "pseudo-class",
 								},
 							});
@@ -425,19 +413,17 @@ export default /** @satisfies {SelectorComplexityRuleDefinition} */ ({
 				}
 
 				if (disallowPseudoElements.length > 0) {
-					let disallowPseudoElementsLocation;
-					for (const pseudoElement of pseudoElementNames) {
-						if (disallowPseudoElements.includes(pseudoElement)) {
-							disallowPseudoElementsLocation =
-								getDisallowedSelectorsLocation(
-									pseudoElementSelectors,
-									pseudoElement,
-								);
+					for (const selectorNode of pseudoElementSelectors) {
+						if (
+							disallowedPseudoElements.has(
+								selectorNode.name.toLowerCase(),
+							)
+						) {
 							context.report({
-								loc: disallowPseudoElementsLocation,
+								loc: selectorNode.loc,
 								messageId: "disallowedSelectors",
 								data: {
-									selectorName: pseudoElement,
+									selectorName: selectorNode.name,
 									selector: "pseudo-element",
 								},
 							});

--- a/src/rules/use-baseline.js
+++ b/src/rules/use-baseline.js
@@ -633,13 +633,15 @@ export default /** @satisfies {UseBaselineRuleDefinition} */ ({
 		 * @returns {void}
 		 */
 		function checkPropertyValueIdentifier(property, child) {
+			const identifier = child.name.toLowerCase();
+
 			// named colors are always valid
-			if (namedColors.has(child.name)) {
+			if (namedColors.has(identifier)) {
 				return;
 			}
 
 			const allowedValues = allowPropertyValuesMap.get(property);
-			if (allowedValues?.has(child.name)) {
+			if (allowedValues?.has(identifier)) {
 				return;
 			}
 
@@ -650,7 +652,7 @@ export default /** @satisfies {UseBaselineRuleDefinition} */ ({
 				return;
 			}
 
-			const featureStatus = possiblePropertyValues.get(child.name);
+			const featureStatus = possiblePropertyValues.get(identifier);
 
 			// if we don't know of any possible property values, just skip it
 			if (featureStatus === undefined) {
@@ -676,11 +678,13 @@ export default /** @satisfies {UseBaselineRuleDefinition} */ ({
 		 * @returns {void}
 		 */
 		function checkPropertyValueFunction(child) {
-			if (allowFunctions.has(child.name)) {
+			const functionName = child.name.toLowerCase();
+
+			if (allowFunctions.has(functionName)) {
 				return;
 			}
 
-			const featureStatus = functions.get(child.name);
+			const featureStatus = functions.get(functionName);
 
 			// if we don't know of any possible property values, just skip it
 			if (featureStatus === undefined) {
@@ -706,11 +710,13 @@ export default /** @satisfies {UseBaselineRuleDefinition} */ ({
 		 * @returns {void}
 		 */
 		function checkPropertyValueUnit(property, child) {
-			if (allowUnits.has(child.unit)) {
+			const unit = child.unit.toLowerCase();
+
+			if (allowUnits.has(unit)) {
 				return;
 			}
 
-			const featureStatus = units.get(child.unit);
+			const featureStatus = units.get(unit);
 
 			// if we don't know of this unit, just skip it
 			if (featureStatus === undefined) {
@@ -743,7 +749,7 @@ export default /** @satisfies {UseBaselineRuleDefinition} */ ({
 					// if a SupportsDeclaration is preceded by "not" then we don't consider it
 					if (
 						conditionChild.type === "Identifier" &&
-						conditionChild.name === "not"
+						conditionChild.name.toLowerCase() === "not"
 					) {
 						i++;
 						continue;
@@ -752,23 +758,29 @@ export default /** @satisfies {UseBaselineRuleDefinition} */ ({
 					// save the supported properties and values for this at-rule
 					if (conditionChild.type === "SupportsDeclaration") {
 						const { declaration } = conditionChild;
-						const property = declaration.property;
+						const property = declaration.property.toLowerCase();
 						const supportedProperty =
 							supportsRule.addProperty(property);
 
 						declaration.value.children.forEach(child => {
 							if (child.type === "Identifier") {
-								supportedProperty.addIdentifier(child.name);
+								supportedProperty.addIdentifier(
+									child.name.toLowerCase(),
+								);
 								return;
 							}
 
 							if (child.type === "Dimension") {
-								supportedProperty.addUnit(child.unit);
+								supportedProperty.addUnit(
+									child.unit.toLowerCase(),
+								);
 								return;
 							}
 
 							if (child.type === "Function") {
-								supportedProperty.addFunction(child.name);
+								supportedProperty.addFunction(
+									child.name.toLowerCase(),
+								);
 							}
 						});
 
@@ -777,18 +789,20 @@ export default /** @satisfies {UseBaselineRuleDefinition} */ ({
 
 					if (
 						conditionChild.type === "FeatureFunction" &&
-						conditionChild.feature === "selector"
+						conditionChild.feature.toLowerCase() === "selector"
 					) {
 						for (const selectorChild of conditionChild.value
 							.children) {
-							supportsRule.addSelector(selectorChild.name);
+							supportsRule.addSelector(
+								selectorChild.name.toLowerCase(),
+							);
 						}
 					}
 				}
 			},
 
 			"Rule > Block > Declaration"(node) {
-				const property = node.property;
+				const property = node.property.toLowerCase();
 
 				// ignore unknown properties - no-invalid-properties already catches this
 				if (!properties.has(property)) {
@@ -855,7 +869,7 @@ export default /** @satisfies {UseBaselineRuleDefinition} */ ({
 						if (
 							!supportsRules.hasPropertyIdentifier(
 								property,
-								child.name,
+								child.name.toLowerCase(),
 							)
 						) {
 							checkPropertyValueIdentifier(property, child);
@@ -866,7 +880,10 @@ export default /** @satisfies {UseBaselineRuleDefinition} */ ({
 
 					if (child.type === "Dimension") {
 						if (
-							!supportsRules.hasPropertyUnit(property, child.unit)
+							!supportsRules.hasPropertyUnit(
+								property,
+								child.unit.toLowerCase(),
+							)
 						) {
 							checkPropertyValueUnit(property, child);
 						}
@@ -878,7 +895,7 @@ export default /** @satisfies {UseBaselineRuleDefinition} */ ({
 						if (
 							!supportsRules.hasPropertyFunction(
 								property,
-								child.name,
+								child.name.toLowerCase(),
 							)
 						) {
 							checkPropertyValueFunction(child);
@@ -895,20 +912,22 @@ export default /** @satisfies {UseBaselineRuleDefinition} */ ({
 				node,
 			) {
 				for (const child of node.children) {
-					// ignore unknown media conditions - no-invalid-at-rules already catches this
-					if (!mediaConditions.has(child.name)) {
-						continue;
-					}
-
 					if (child.type !== "Feature") {
 						continue;
 					}
 
-					if (allowMediaConditions.has(child.name)) {
+					const condition = child.name.toLowerCase();
+
+					// ignore unknown media conditions - no-invalid-at-rules already catches this
+					if (!mediaConditions.has(condition)) {
 						continue;
 					}
 
-					const featureStatus = mediaConditions.get(child.name);
+					if (allowMediaConditions.has(condition)) {
+						continue;
+					}
+
+					const featureStatus = mediaConditions.get(condition);
 
 					if (!baselineAvailability.isSupported(featureStatus)) {
 						const loc = child.loc;
@@ -976,21 +995,22 @@ export default /** @satisfies {UseBaselineRuleDefinition} */ ({
 
 			"PseudoClassSelector,PseudoElementSelector"(node) {
 				const selector = node.name;
+				const selectorName = selector.toLowerCase();
 
-				if (!selectors.has(selector)) {
+				if (!selectors.has(selectorName)) {
 					return;
 				}
 
-				if (allowSelectors.has(selector)) {
+				if (allowSelectors.has(selectorName)) {
 					return;
 				}
 
 				// if the selector has been tested in a @supports rule, don't check it
-				if (supportsRules.hasSelector(selector)) {
+				if (supportsRules.hasSelector(selectorName)) {
 					return;
 				}
 
-				const featureStatus = selectors.get(selector);
+				const featureStatus = selectors.get(selectorName);
 
 				if (!baselineAvailability.isSupported(featureStatus)) {
 					const loc = node.loc;

--- a/src/rules/use-layers.js
+++ b/src/rules/use-layers.js
@@ -78,7 +78,9 @@ export default /** @satisfies {UseLayersRuleDefinition} */ ({
 				// layer, if present, must always be the second child of the prelude
 				const secondChild = node.prelude?.children[1];
 				const layerNode =
-					secondChild?.name === "layer" ? secondChild : null;
+					secondChild?.name?.toLowerCase() === "layer"
+						? secondChild
+						: null;
 
 				if (options.requireImportLayers && !layerNode) {
 					context.report({

--- a/tests/rules/font-family-fallbacks.test.js
+++ b/tests/rules/font-family-fallbacks.test.js
@@ -69,6 +69,7 @@ ruleTester.run("font-family-fallbacks", rule, {
 		":root { --my-font: Arial, SANS-SERIF; } a { font: 16px/1.5 Helvetica, var(--my-font); }",
 		"a { font: 16px/1.5 Arial, var(--x), SANS-SERIF; }",
 		"a { font: var(--font-weight) var(--font-size)/var(--line-height) MONOSPACE; }",
+		":root { --my-font: SANS-SERIF; } a { font-family: VAR(--my-font); }",
 	],
 	invalid: [
 		{
@@ -108,6 +109,18 @@ ruleTester.run("font-family-fallbacks", rule, {
 			],
 		},
 		{
+			code: "a { FONT-FAMILY: 'Arial'; }",
+			errors: [
+				{
+					messageId: "useFallbackFonts",
+					line: 1,
+					column: 18,
+					endLine: 1,
+					endColumn: 25,
+				},
+			],
+		},
+		{
 			code: "a { font-family: 'Arial', 'Segoe UI Emoji'; }",
 			errors: [
 				{
@@ -132,7 +145,31 @@ ruleTester.run("font-family-fallbacks", rule, {
 			],
 		},
 		{
+			code: "a { FONT-FAMILY: VAR(--my-font), 'Arial'; }",
+			errors: [
+				{
+					messageId: "useGenericFont",
+					line: 1,
+					column: 18,
+					endLine: 1,
+					endColumn: 41,
+				},
+			],
+		},
+		{
 			code: ":root { --my-font: 'Arial', 'Segoe UI Emoji'; } a { font-family: 'Segoe UI', var(--my-font); }",
+			errors: [
+				{
+					messageId: "useGenericFont",
+					line: 1,
+					column: 66,
+					endLine: 1,
+					endColumn: 92,
+				},
+			],
+		},
+		{
+			code: ":root { --my-font: 'Arial', 'Segoe UI Emoji'; } a { FONT-FAMILY: 'Segoe UI', VAR(--my-font); }",
 			errors: [
 				{
 					messageId: "useGenericFont",
@@ -192,6 +229,18 @@ ruleTester.run("font-family-fallbacks", rule, {
 			],
 		},
 		{
+			code: "a { FONT: 1.2em 'Arial'; }",
+			errors: [
+				{
+					messageId: "useFallbackFonts",
+					line: 1,
+					column: 11,
+					endLine: 1,
+					endColumn: 24,
+				},
+			],
+		},
+		{
 			code: "a { font: 1.2em 'Arial', 'Fira Sans'; }",
 			errors: [
 				{
@@ -228,6 +277,18 @@ ruleTester.run("font-family-fallbacks", rule, {
 			],
 		},
 		{
+			code: "a { FONT: VAR(--font-size) 'Open Sans'; }",
+			errors: [
+				{
+					messageId: "useFallbackFonts",
+					line: 1,
+					column: 11,
+					endLine: 1,
+					endColumn: 39,
+				},
+			],
+		},
+		{
 			code: "a { font: var(--font-size) 'Roboto', 'Open Sans'; }",
 			errors: [
 				{
@@ -252,7 +313,31 @@ ruleTester.run("font-family-fallbacks", rule, {
 			],
 		},
 		{
+			code: ":root { --my-font: 'Roboto', 'Open Sans'; } a { FONT: var(--font-size) 'Open Sans', VAR(--my-font); }",
+			errors: [
+				{
+					messageId: "useGenericFont",
+					line: 1,
+					column: 55,
+					endLine: 1,
+					endColumn: 99,
+				},
+			],
+		},
+		{
 			code: "a { font: var(--font-size) 'Open Sans', var(--my-font), 'Roboto'; }",
+			errors: [
+				{
+					messageId: "useGenericFont",
+					line: 1,
+					column: 11,
+					endLine: 1,
+					endColumn: 65,
+				},
+			],
+		},
+		{
+			code: "a { FONT: VAR(--font-size) 'Open Sans', VAR(--my-font), 'Roboto'; }",
 			errors: [
 				{
 					messageId: "useGenericFont",

--- a/tests/rules/prefer-logical-properties.test.js
+++ b/tests/rules/prefer-logical-properties.test.js
@@ -20,10 +20,13 @@ const ruleTester = new RuleTester({
 ruleTester.run("prefer-logical-properties", rule, {
 	valid: [
 		"a { margin-block: 10px; }",
+		"a { MARGIN-BLOCK: 10px; }",
 		"a { padding-inline: 20px; }",
+		"a { PADDING-INLINE: 20PX; }",
 		"a { margin: 10px; }",
 		"a { padding: 20px; }",
 		"a { text-align: start }",
+		"a { TEXT-ALIGN: START }",
 		"@supports (text-align: left) {}",
 		"@supports (padding-left: 10px) {}",
 		{
@@ -35,7 +38,23 @@ ruleTester.run("prefer-logical-properties", rule, {
 			],
 		},
 		{
+			code: "a { PADDING-LEFT: 20px; }",
+			options: [
+				{
+					allowProperties: ["padding-left"],
+				},
+			],
+		},
+		{
 			code: "a { inline-size: 100vw; }",
+			options: [
+				{
+					allowUnits: ["vw"],
+				},
+			],
+		},
+		{
+			code: "a { inline-size: 100VW; }",
 			options: [
 				{
 					allowUnits: ["vw"],
@@ -62,6 +81,32 @@ ruleTester.run("prefer-logical-properties", rule, {
 							messageId: "replaceWithLogicalProperty",
 							data: {
 								property: "margin-top",
+								replacement: "margin-block-start",
+							},
+							output: "a { margin-block-start: 10px; }",
+						},
+					],
+				},
+			],
+		},
+		{
+			code: "a { MARGIN-TOP: 10px; }",
+			errors: [
+				{
+					messageId: "notLogicalProperty",
+					line: 1,
+					column: 5,
+					endLine: 1,
+					endColumn: 21,
+					data: {
+						property: "MARGIN-TOP",
+						replacement: "margin-block-start",
+					},
+					suggestions: [
+						{
+							messageId: "replaceWithLogicalProperty",
+							data: {
+								property: "MARGIN-TOP",
 								replacement: "margin-block-start",
 							},
 							output: "a { margin-block-start: 10px; }",
@@ -123,6 +168,32 @@ ruleTester.run("prefer-logical-properties", rule, {
 			],
 		},
 		{
+			code: "a { TEXT-ALIGN: LEFT }",
+			errors: [
+				{
+					messageId: "notLogicalValue",
+					line: 1,
+					column: 17,
+					endLine: 1,
+					endColumn: 21,
+					data: {
+						value: "LEFT",
+						replacement: "start",
+					},
+					suggestions: [
+						{
+							messageId: "replaceWithLogicalValue",
+							data: {
+								value: "LEFT",
+								replacement: "start",
+							},
+							output: "a { TEXT-ALIGN: start }",
+						},
+					],
+				},
+			],
+		},
+		{
 			code: "a { block-size: 100vh }",
 			errors: [
 				{
@@ -143,6 +214,32 @@ ruleTester.run("prefer-logical-properties", rule, {
 								replacement: "vb",
 							},
 							output: "a { block-size: 100vb }",
+						},
+					],
+				},
+			],
+		},
+		{
+			code: "a { BLOCK-SIZE: 100VH }",
+			errors: [
+				{
+					messageId: "notLogicalUnit",
+					line: 1,
+					column: 17,
+					endLine: 1,
+					endColumn: 22,
+					data: {
+						unit: "VH",
+						replacement: "vb",
+					},
+					suggestions: [
+						{
+							messageId: "replaceWithLogicalUnit",
+							data: {
+								unit: "VH",
+								replacement: "vb",
+							},
+							output: "a { BLOCK-SIZE: 100vb }",
 						},
 					],
 				},

--- a/tests/rules/relative-font-units.test.js
+++ b/tests/rules/relative-font-units.test.js
@@ -31,7 +31,9 @@ ruleTester.run("relative-font-units", rule, {
 		"a { font-size: 1REM; }",
 		"a { font-size: 1Rem; }",
 		"a { font-size: 1rEm; }",
+		"a { FONT-SIZE: 1rEm; }",
 		"a { font: 2REM Arial, sans-serif; }",
+		"a { FONT: 2REM Arial, sans-serif; }",
 		"a { font: 1.2REM/2 Arial, sans-serif; }",
 		"a { font-size: var(--foo); }",
 		"a { font: var(--foo) Arial; }",
@@ -334,6 +336,19 @@ ruleTester.run("relative-font-units", rule, {
 	invalid: [
 		{
 			code: "a { font-size: 1px; }",
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+					line: 1,
+					column: 16,
+					endLine: 1,
+					endColumn: 19,
+					data: { allowedFontUnits: "rem" },
+				},
+			],
+		},
+		{
+			code: "a { FONT-SIZE: 1PX; }",
 			errors: [
 				{
 					messageId: "allowedFontUnits",
@@ -1200,6 +1215,19 @@ ruleTester.run("relative-font-units", rule, {
 					endLine: 2,
 					endColumn: 27,
 					data: { allowedFontUnits: "lh, rex, %" },
+				},
+			],
+		},
+		{
+			code: "a { FONT: 2EM Arial, sans-serif; }",
+			errors: [
+				{
+					messageId: "allowedFontUnits",
+					line: 1,
+					column: 11,
+					endLine: 1,
+					endColumn: 14,
+					data: { allowedFontUnits: "rem" },
 				},
 			],
 		},

--- a/tests/rules/selector-complexity.test.js
+++ b/tests/rules/selector-complexity.test.js
@@ -616,6 +616,57 @@ ruleTester.run("selector-complexity", rule, {
 			],
 		},
 		{
+			code: "a:hover {}",
+			options: [{ disallowPseudoClasses: ["HOVER"] }],
+			errors: [
+				{
+					messageId: "disallowedSelectors",
+					data: {
+						selectorName: "hover",
+						selector: "pseudo-class",
+					},
+					line: 1,
+					column: 2,
+					endLine: 1,
+					endColumn: 8,
+				},
+			],
+		},
+		{
+			code: "a:HOVER {}",
+			options: [{ disallowPseudoClasses: ["hover"] }],
+			errors: [
+				{
+					messageId: "disallowedSelectors",
+					data: {
+						selectorName: "HOVER",
+						selector: "pseudo-class",
+					},
+					line: 1,
+					column: 2,
+					endLine: 1,
+					endColumn: 8,
+				},
+			],
+		},
+		{
+			code: "a:HOVER {}",
+			options: [{ disallowPseudoClasses: ["HOVER"] }],
+			errors: [
+				{
+					messageId: "disallowedSelectors",
+					data: {
+						selectorName: "HOVER",
+						selector: "pseudo-class",
+					},
+					line: 1,
+					column: 2,
+					endLine: 1,
+					endColumn: 8,
+				},
+			],
+		},
+		{
 			code: "li:first-child:hover {}",
 			options: [{ disallowPseudoClasses: ["hover", "first-child"] }],
 			errors: [
@@ -651,6 +702,57 @@ ruleTester.run("selector-complexity", rule, {
 					messageId: "disallowedSelectors",
 					data: {
 						selectorName: "marker",
+						selector: "pseudo-element",
+					},
+					line: 1,
+					column: 3,
+					endLine: 1,
+					endColumn: 11,
+				},
+			],
+		},
+		{
+			code: "li::marker {}",
+			options: [{ disallowPseudoElements: ["MARKER"] }],
+			errors: [
+				{
+					messageId: "disallowedSelectors",
+					data: {
+						selectorName: "marker",
+						selector: "pseudo-element",
+					},
+					line: 1,
+					column: 3,
+					endLine: 1,
+					endColumn: 11,
+				},
+			],
+		},
+		{
+			code: "li::MARKER {}",
+			options: [{ disallowPseudoElements: ["marker"] }],
+			errors: [
+				{
+					messageId: "disallowedSelectors",
+					data: {
+						selectorName: "MARKER",
+						selector: "pseudo-element",
+					},
+					line: 1,
+					column: 3,
+					endLine: 1,
+					endColumn: 11,
+				},
+			],
+		},
+		{
+			code: "li::MARKER {}",
+			options: [{ disallowPseudoElements: ["MARKER"] }],
+			errors: [
+				{
+					messageId: "disallowedSelectors",
+					data: {
+						selectorName: "MARKER",
 						selector: "pseudo-element",
 					},
 					line: 1,

--- a/tests/rules/use-baseline.test.js
+++ b/tests/rules/use-baseline.test.js
@@ -70,8 +70,20 @@ ruleTester.run("use-baseline", rule, {
 		`@supports (width: abs(20% - 100px)) {
 			a { width: abs(20% - 100px); }
 		}`,
+		`@supports (WIDTH: ABS(20% - 100px)) {
+			a { width: abs(20% - 100px); }
+		}`,
 		`@supports selector(:fullscreen) {
 				h1:fullscreen { color: red; }
+		}`,
+		`@SUPPORTS SELECTOR(:fullscreen) {
+			h1:fullscreen { color: red; }
+		}`,
+		`@supports selector(:FULLSCREEN) {
+			h1:fullscreen { color: red; }
+		}`,
+		`@SUPPORTS (IMAGE-RENDERING: SMOOTH) {
+			a { image-rendering: smooth; }
 		}`,
 		"div { cursor: pointer; }",
 		"pre { overflow: auto; }",
@@ -167,6 +179,10 @@ ruleTester.run("use-baseline", rule, {
 		"a { margin: 0; }",
 		"@supports (height: 100svh) { a { height: 100svh; } }",
 		{
+			code: "@supports (HEIGHT: 100SVH) { a { height: 100svh; } }",
+			options: [{ available: 2021 }],
+		},
+		{
 			code: "a { height: 100svh; }",
 			options: [{ allowUnits: ["svh"] }],
 		},
@@ -200,6 +216,22 @@ ruleTester.run("use-baseline", rule, {
 					column: 24,
 					endLine: 1,
 					endColumn: 39,
+				},
+			],
+		},
+		{
+			code: "a { ACCENT-COLOR: AUTO; }",
+			errors: [
+				{
+					messageId: "notBaselineProperty",
+					data: {
+						property: "accent-color",
+						availability: "widely",
+					},
+					line: 1,
+					column: 5,
+					endLine: 1,
+					endColumn: 17,
 				},
 			],
 		},
@@ -356,6 +388,23 @@ ruleTester.run("use-baseline", rule, {
 			],
 		},
 		{
+			code: "a { IMAGE-RENDERING: SMOOTH; }",
+			errors: [
+				{
+					messageId: "notBaselinePropertyValue",
+					data: {
+						property: "image-rendering",
+						value: "SMOOTH",
+						availability: "widely",
+					},
+					line: 1,
+					column: 22,
+					endLine: 1,
+					endColumn: 28,
+				},
+			],
+		},
+		{
 			code: "@supports (accent-color: auto) { a { accent-color: abs(20% - 10px); } }",
 			errors: [
 				{
@@ -373,6 +422,22 @@ ruleTester.run("use-baseline", rule, {
 		},
 		{
 			code: "@supports not (accent-color: auto) { a { accent-color: auto } }",
+			errors: [
+				{
+					messageId: "notBaselineProperty",
+					data: {
+						property: "accent-color",
+						availability: "widely",
+					},
+					line: 1,
+					column: 42,
+					endLine: 1,
+					endColumn: 54,
+				},
+			],
+		},
+		{
+			code: "@supports NOT (accent-color: auto) { a { accent-color: auto; } }",
 			errors: [
 				{
 					messageId: "notBaselineProperty",
@@ -420,6 +485,22 @@ ruleTester.run("use-baseline", rule, {
 			],
 		},
 		{
+			code: "a { color: LIGHT-DARK(black, white); }",
+			errors: [
+				{
+					messageId: "notBaselineFunction",
+					data: {
+						function: "LIGHT-DARK",
+						availability: "widely",
+					},
+					line: 1,
+					column: 12,
+					endLine: 1,
+					endColumn: 36,
+				},
+			],
+		},
+		{
 			code: 'a { background-image: image("foo.png", red); }',
 			errors: [
 				{
@@ -442,6 +523,22 @@ ruleTester.run("use-baseline", rule, {
 					messageId: "notBaselineMediaCondition",
 					data: {
 						condition: "inverted-colors",
+						availability: "widely",
+					},
+					line: 1,
+					column: 9,
+					endLine: 1,
+					endColumn: 24,
+				},
+			],
+		},
+		{
+			code: "@MEDIA (INVERTED-COLORS: INVERTED) { a { color: red; } }",
+			errors: [
+				{
+					messageId: "notBaselineMediaCondition",
+					data: {
+						condition: "INVERTED-COLORS",
 						availability: "widely",
 					},
 					line: 1,
@@ -518,6 +615,22 @@ ruleTester.run("use-baseline", rule, {
 					messageId: "notBaselineSelector",
 					data: {
 						selector: "fullscreen",
+						availability: "widely",
+					},
+					line: 1,
+					column: 3,
+					endLine: 1,
+					endColumn: 14,
+				},
+			],
+		},
+		{
+			code: "h1:FULLSCREEN { margin: 0; }",
+			errors: [
+				{
+					messageId: "notBaselineSelector",
+					data: {
+						selector: "FULLSCREEN",
 						availability: "widely",
 					},
 					line: 1,
@@ -782,6 +895,23 @@ ruleTester.run("use-baseline", rule, {
 					messageId: "notBaselineUnit",
 					data: {
 						unit: "dvh",
+						availability: 2021,
+					},
+					line: 1,
+					column: 13,
+					endLine: 1,
+					endColumn: 19,
+				},
+			],
+		},
+		{
+			code: "a { HEIGHT: 100DVH; }",
+			options: [{ available: 2021 }],
+			errors: [
+				{
+					messageId: "notBaselineUnit",
+					data: {
+						unit: "DVH",
 						availability: 2021,
 					},
 					line: 1,

--- a/tests/rules/use-layers.test.js
+++ b/tests/rules/use-layers.test.js
@@ -38,6 +38,7 @@ ruleTester.run("use-layers", rule, {
 		"@LAYER bar { a { color: red; } }",
 		"@Layer foo { a { color: red; } }",
 		"@IMPORT 'foo.css' layer(foo);",
+		"@IMPORT 'foo.css' LAYER(foo);",
 		dedent`
 			@media (min-width: 600px) {
 				@LAYER foo {
@@ -68,6 +69,10 @@ ruleTester.run("use-layers", rule, {
 			options: [{ allowUnnamedLayers: true }],
 		},
 		{
+			code: "@import 'foo.css' LAYER;",
+			options: [{ allowUnnamedLayers: true }],
+		},
+		{
 			code: "@import 'foo.css';",
 			options: [{ requireImportLayers: false }],
 		},
@@ -89,6 +94,10 @@ ruleTester.run("use-layers", rule, {
 		},
 		{
 			code: "@import 'foo.css' layer(foo.bar);",
+			options: [{ layerNamePattern: "^(foo|bar)$" }],
+		},
+		{
+			code: "@import 'foo.css' LAYER(foo.bar);",
 			options: [{ layerNamePattern: "^(foo|bar)$" }],
 		},
 		{
@@ -263,6 +272,18 @@ ruleTester.run("use-layers", rule, {
 			],
 		},
 		{
+			code: "@import 'foo.css' LAYER;",
+			errors: [
+				{
+					messageId: "missingLayerName",
+					line: 1,
+					column: 19,
+					endLine: 1,
+					endColumn: 24,
+				},
+			],
+		},
+		{
 			code: "@layer foo, baz { a { color: bar } }",
 			options: [{ layerNamePattern: "bar" }],
 			errors: [
@@ -348,6 +369,23 @@ ruleTester.run("use-layers", rule, {
 		},
 		{
 			code: "@import 'foo.css' layer(baz);",
+			options: [{ layerNamePattern: "bar" }],
+			errors: [
+				{
+					messageId: "layerNameMismatch",
+					data: {
+						name: "baz",
+						pattern: "bar",
+					},
+					line: 1,
+					column: 25,
+					endLine: 1,
+					endColumn: 28,
+				},
+			],
+		},
+		{
+			code: "@import 'foo.css' LAYER(baz);",
 			options: [{ layerNamePattern: "bar" }],
 			errors: [
 				{


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

CSS properties, keywords, functions, units, media features, and pseudo-class/element names are case-insensitive. This PR ensures that the affected rules recognize them regardless of capitalization.

#### What changes did you make? (Give an overview)

Updated the affected rules to handle these CSS constructs case-insensitively.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

If this is difficult to review as a single PR, I’m happy to split it into smaller PRs.
