### PR TITLE
fix: recognize `at-rule()` feature queries in `use-baseline`

### DIFF
--- a/docs/rules/use-baseline.md
+++ b/docs/rules/use-baseline.md
@@ -25,7 +25,7 @@ While using only Baseline widely available features can help ensure the greatest
 This rule warns when it finds any of the following:
 
 - A CSS property that isn't widely available or otherwise isn't enclosed in a `@supports` block.
-- An at-rule that isn't widely available.
+- An at-rule that isn't widely available or isn't guarded by a matching `@supports at-rule()` query.
 - A media condition inside `@media` that isn't widely available.
 - A CSS property value that isn't widely available or otherwise isn't enclosed in a `@supports` block (currently limited to identifiers only).
 - A CSS property function that isn't widely available.
@@ -98,6 +98,15 @@ Examples of **correct** code:
 @supports (accent-color: auto) {
 	a {
 		accent-color: auto;
+	}
+}
+
+/* valid - @supports indicates you're choosing a limited availability at-rule */
+@supports at-rule(@scope) {
+	@scope (.card) {
+		a {
+			color: red;
+		}
 	}
 }
 ```

--- a/src/rules/use-baseline.js
+++ b/src/rules/use-baseline.js
@@ -177,6 +177,12 @@ class SupportsRule {
 	#selectors = new Set();
 
 	/**
+	 * The at-rules supported by this rule.
+	 * @type {Set<string>}
+	 */
+	#atRules = new Set();
+
+	/**
 	 * Adds a property to the rule.
 	 * @param {string} property The name of the property.
 	 * @returns {SupportedProperty} The supported property object.
@@ -320,6 +326,24 @@ class SupportsRule {
 	hasSelector(selector) {
 		return this.#selectors.has(selector);
 	}
+
+	/**
+	 * Adds an at-rule to the rule.
+	 * @param {string} atRule The name of the at-rule.
+	 * @returns {void}
+	 */
+	addAtRule(atRule) {
+		this.#atRules.add(atRule);
+	}
+
+	/**
+	 * Determines if the rule supports an at-rule.
+	 * @param {string} atRule The name of the at-rule.
+	 * @returns {boolean} `true` if the at-rule is supported, `false` if not.
+	 */
+	hasAtRule(atRule) {
+		return this.#atRules.has(atRule);
+	}
 }
 
 /**
@@ -423,6 +447,15 @@ class SupportsRules {
 	 */
 	hasSelector(selector) {
 		return this.#rules.some(rule => rule.hasSelector(selector));
+	}
+
+	/**
+	 * Determines if any rule supports an at-rule.
+	 * @param {string} atRule The name of the at-rule.
+	 * @returns {boolean} `true` if any rule supports the at-rule, `false` if not.
+	 */
+	hasAtRule(atRule) {
+		return this.#rules.some(rule => rule.hasAtRule(atRule));
 	}
 }
 
@@ -775,14 +808,26 @@ export default /** @satisfies {UseBaselineRuleDefinition} */ ({
 						continue;
 					}
 
-					if (
-						conditionChild.type === "FeatureFunction" &&
-						conditionChild.feature === "selector"
-					) {
+					if (conditionChild.type !== "FeatureFunction") {
+						continue;
+					}
+
+					const feature = conditionChild.feature.toLowerCase();
+
+					if (feature === "selector") {
 						for (const selectorChild of conditionChild.value
 							.children) {
 							supportsRule.addSelector(selectorChild.name);
 						}
+
+						continue;
+					}
+
+					if (feature === "at-rule") {
+						const atRule = conditionChild.value.value
+							.slice(1)
+							.toLowerCase();
+						supportsRule.addAtRule(atRule);
 					}
 				}
 			},
@@ -947,6 +992,10 @@ export default /** @satisfies {UseBaselineRuleDefinition} */ ({
 				}
 
 				if (allowAtRules.has(atRuleName)) {
+					return;
+				}
+
+				if (supportsRules.hasAtRule(atRuleName)) {
 					return;
 				}
 

--- a/tests/rules/use-baseline.test.js
+++ b/tests/rules/use-baseline.test.js
@@ -73,6 +73,16 @@ ruleTester.run("use-baseline", rule, {
 		`@supports selector(:fullscreen) {
 				h1:fullscreen { color: red; }
 		}`,
+		`@supports at-rule(@scope) {
+			@scope (.card) {
+				a { color: red; }
+			}
+		}`,
+		`@SUPPORTS AT-RULE(@SCOPE) {
+			@scope (.card) {
+				a { color: red; }
+			}
+		}`,
 		"div { cursor: pointer; }",
 		"pre { overflow: auto; }",
 		".highlight, #highlight, highlight { color: red }",
@@ -546,6 +556,22 @@ ruleTester.run("use-baseline", rule, {
 					column: 7,
 					endLine: 4,
 					endColumn: 18,
+				},
+			],
+		},
+		{
+			code: "@supports at-rule(@scope) {}\n@supports (color: red) {\n@scope (.card) { a { color: red; } }\n}",
+			errors: [
+				{
+					messageId: "notBaselineAtRule",
+					data: {
+						atRule: "scope",
+						availability: "widely",
+					},
+					line: 3,
+					column: 1,
+					endLine: 3,
+					endColumn: 7,
 				},
 			],
 		},

--- a/tests/rules/use-baseline.test.js
+++ b/tests/rules/use-baseline.test.js
@@ -576,6 +576,22 @@ ruleTester.run("use-baseline", rule, {
 			],
 		},
 		{
+			code: "@supports at-rule(@scope) {\n@view-transition { navigation: auto; }\n}",
+			errors: [
+				{
+					messageId: "notBaselineAtRule",
+					data: {
+						atRule: "view-transition",
+						availability: "widely",
+					},
+					line: 2,
+					column: 1,
+					endLine: 2,
+					endColumn: 17,
+				},
+			],
+		},
+		{
 			code: "details::details-content { background-color: #a29bfe; }",
 			errors: [
 				{


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What did you do?

```css
/* eslint css/use-baseline: "error" */

@supports at-rule(@scope) {
	@scope (.card) {
		a {
			color: red;
		}
	}
}
```

#### What did you expect to happen?

No lint error, because `@scope` is guarded by its matching feature query.

#### What actually happened?

`use-baseline` reported:
```
At-rule '@scope' is not a widely available baseline feature.
```

#### What is the purpose of this pull request?

This PR makes `use-baseline` recognize `@supports at-rule()` feature queries, so at-rules used as progressive enhancements are not incorrectly reported as baseline violations.

#### What changes did you make? (Give an overview)

- Added `at-rule()` handling for `@supports` conditions in `use-baseline`.
- Documented the supported `@supports at-rule()` pattern.

#### Related Issues

Blocked on https://github.com/eslint/csstree/pull/148

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the `use-baseline` rule to recognize `@supports at-rule()` conditions when evaluating at-rules.
  - Baseline checks now account for matching support conditions, including case-insensitive syntax.

- **Documentation**
  - Clarified how at-rules should be guarded with matching `@supports at-rule()` queries.
  - Added examples demonstrating supported and unsupported at-rule usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->