### PR TITLE
fix: allow additional properties in `CSSLanguageOptions`

### DIFF
--- a/src/languages/css-language.js
+++ b/src/languages/css-language.js
@@ -25,24 +25,11 @@ import { visitorKeys } from "./css-visitor-keys.js";
 /**
  * @import { CssNodePlain, Comment, Lexer, StyleSheetPlain, SyntaxConfig } from "@eslint/css-tree"
  * @import { Language, OkParseResult, ParseResult, File, FileError } from "@eslint/core";
+ * @import { CSSLanguageOptions } from "../types.js";
  */
 
 /** @typedef {OkParseResult<StyleSheetPlain> & { comments: Comment[], lexer: Lexer }} CSSOkParseResult */
 /** @typedef {ParseResult<StyleSheetPlain>} CSSParseResult */
-/**
- * DefaultSyntaxConfig type representing the structure returned by `@eslint/css-tree/definition-syntax-data`.
- * This type is defined inline because it's not exported from the main `@eslint/css-tree` package.
- * @typedef {Pick<SyntaxConfig, "atrules" | "types" | "properties">} DefaultSyntaxConfig
- */
-/**
- * @typedef {(defaultSyntax: DefaultSyntaxConfig) => Partial<SyntaxConfig>} SyntaxExtensionCallback
- */
-/**
- * @typedef {Object} CSSLanguageOptions
- * @property {boolean} [tolerant] Whether to be tolerant of recoverable parsing errors.
- * @property {Partial<SyntaxConfig> | SyntaxExtensionCallback} [customSyntax] Custom syntax to use for parsing.
- */
-
 //-----------------------------------------------------------------------------
 // Helpers
 //-----------------------------------------------------------------------------

--- a/src/languages/css-source-code.js
+++ b/src/languages/css-source-code.js
@@ -22,8 +22,7 @@ import { visitorKeys } from "./css-visitor-keys.js";
 /**
  * @import { CssNode, CssNodePlain, CssLocationRange, Comment, Lexer, StyleSheetPlain } from "@eslint/css-tree"
  * @import { SourceRange, FileProblem, DirectiveType, RulesConfig } from "@eslint/core"
- * @import { CSSSyntaxElement } from "../types.js"
- * @import { CSSLanguageOptions } from "./css-language.js"
+ * @import { CSSLanguageOptions, CSSSyntaxElement } from "../types.js"
  */
 
 //-----------------------------------------------------------------------------

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,18 +7,54 @@
 // Imports
 //------------------------------------------------------------------------------
 
-import type { RuleVisitor } from "@eslint/core";
-import type { CssNodePlain, StyleSheetPlain } from "@eslint/css-tree";
+import type { LanguageOptions, RuleVisitor } from "@eslint/core";
+import type {
+	CssNodePlain,
+	StyleSheetPlain,
+	SyntaxConfig,
+} from "@eslint/css-tree";
 import type {
 	CustomRuleDefinitionType,
 	CustomRuleTypeDefinitions,
 	CustomRuleVisitorWithExit,
 } from "@eslint/plugin-kit";
-import type { CSSLanguageOptions, CSSSourceCode } from "./index.js";
+import type { CSSSourceCode } from "./index.js";
 
 //------------------------------------------------------------------------------
 // Types
 //------------------------------------------------------------------------------
+
+/**
+ * Default syntax configuration representing the structure returned by
+ * `@eslint/css-tree/definition-syntax-data`.
+ */
+export type DefaultSyntaxConfig = Pick<
+	SyntaxConfig,
+	"atrules" | "types" | "properties"
+>;
+
+/**
+ * A callback used to extend the default CSS syntax configuration.
+ */
+export type SyntaxExtensionCallback = (
+	defaultSyntax: DefaultSyntaxConfig,
+) => Partial<SyntaxConfig>;
+
+/**
+ * Language options provided for CSS files.
+ */
+export interface CSSLanguageOptions extends LanguageOptions {
+	/**
+	 * Whether to be tolerant of recoverable parsing errors.
+	 * @default false
+	 */
+	tolerant?: boolean;
+
+	/**
+	 * Custom syntax to use for parsing.
+	 */
+	customSyntax?: Partial<SyntaxConfig> | SyntaxExtensionCallback;
+}
 
 /**
  * A CSS syntax element, including nodes and comments.

--- a/tests/types/types.test.ts
+++ b/tests/types/types.test.ts
@@ -1,5 +1,6 @@
 import css from "@eslint/css";
 import type {
+	CSSLanguageOptions,
 	CSSRuleDefinition,
 	CSSRuleVisitor,
 	CSSSourceCode,
@@ -74,6 +75,23 @@ css.rules[ruleName] satisfies CSSRuleDefinition;
 
 // Check that `plugins` in the recommended config is defined:
 css.configs.recommended.plugins satisfies object;
+
+const validLanguageOptions1: CSSLanguageOptions = {};
+const validLanguageOptions2: CSSLanguageOptions = {
+	tolerant: true,
+};
+const validLanguageOptions3: CSSLanguageOptions = {
+	tolerant: false,
+};
+const validLanguageOptions4: CSSLanguageOptions = {
+	tolerant: true,
+	unknownOption: "unknown",
+};
+
+const invalidLanguageOptions1: CSSLanguageOptions = {
+	// @ts-expect-error -- Invalid value for `tolerant`
+	tolerant: "true",
+};
 
 {
 	type RecommendedRuleName = keyof typeof css.configs.recommended.rules;


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

## Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

## AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

## What is the purpose of this pull request?

While https://github.com/eslint/eslint/issues/19615#issuecomment-2810360453 determined that `XXXLanguageOptions` can have additional properties, and [`MarkdownLanguageOptions` already extends the `LanguageOptions` type from `@eslint/core`](https://github.com/eslint/markdown/blob/main/src/types.ts#L136-L151), the corresponding `CSSLanguageOptions`  does not allow additional properties.

## What changes did you make? (Give an overview)

So, I’ve updated `CSSLanguageOptions` to extend `LanguageOptions` from `@eslint/core` and added type test cases to verify that it allows additional properties.

Just a note: `CSSLanguageOptions` was already being exported from the main entry point, so this PR doesn’t introduce a new feature and only includes a fix.

## Related Issues

- https://github.com/eslint/eslint/issues/19615#issuecomment-2810360453
- https://github.com/eslint/markdown/blob/main/src/types.ts#L136-L151
- https://github.com/eslint/json/pull/271

<!-- include tags like "fixes #123" or "refs #123" -->

## Is there anything you'd like reviewers to focus on?

I found it while working on https://github.com/eslint/markdown/pull/706.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved TypeScript definitions for CSS language configuration options.
  - Added clearer typing for custom syntax configuration and syntax extension callbacks.
  - Clarified support for tolerant parsing and default syntax configuration.

- **Tests**
  - Expanded type coverage for valid and invalid CSS language options, custom syntax settings, tolerant parsing, and property syntax validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->