### PR TITLE
fix: locate `!important` after the value in `no-important`

### DIFF
--- a/src/rules/no-important.js
+++ b/src/rules/no-important.js
@@ -58,12 +58,16 @@ export default /** @satisfies {NoImportantRuleDefinition} */ ({
 						/* eslint-disable-next-line require-unicode-regexp -- we want to replace each code unit with a space */
 						match => match.replace(/[^\r\n\f]/g, " "),
 					);
-					const importantMatch =
-						importantPattern.exec(textWithoutComments);
-					const importantStartOffset = importantMatch.index;
+					const nodeStartOffset = node.loc.start.offset;
+					const valueEndOffset =
+						node.value.loc.end.offset - nodeStartOffset;
+					const importantMatch = importantPattern.exec(
+						textWithoutComments.slice(valueEndOffset),
+					);
+					const importantStartOffset =
+						valueEndOffset + importantMatch.index;
 					const importantEndOffset =
 						importantStartOffset + importantMatch[0].length;
-					const nodeStartOffset = node.loc.start.offset;
 
 					context.report({
 						loc: {

--- a/tests/rules/no-important.test.js
+++ b/tests/rules/no-important.test.js
@@ -50,6 +50,7 @@ ruleTester.run("no-important", rule, {
 		"a { color: red /* !important */; }",
 		"a { color: /* !important */ red; }",
 		"a { color: red; /* !important */ background: blue; }",
+		'a { content: "!important"; }',
 	],
 	invalid: [
 		{
@@ -887,6 +888,78 @@ ruleTester.run("no-important", rule, {
 								color: red;
 							}
 							`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: 'a { content: "!important" !important; }',
+			errors: [
+				{
+					messageId: "unexpectedImportant",
+					line: 1,
+					column: 27,
+					endLine: 1,
+					endColumn: 37,
+					suggestions: [
+						{
+							messageId: "removeImportant",
+							output: 'a { content: "!important"; }',
+						},
+					],
+				},
+			],
+		},
+		{
+			code: 'a { content: "x ! important y" !important; }',
+			errors: [
+				{
+					messageId: "unexpectedImportant",
+					line: 1,
+					column: 32,
+					endLine: 1,
+					endColumn: 42,
+					suggestions: [
+						{
+							messageId: "removeImportant",
+							output: 'a { content: "x ! important y"; }',
+						},
+					],
+				},
+			],
+		},
+		{
+			code: "a { background: url(!important.png) !important; }",
+			errors: [
+				{
+					messageId: "unexpectedImportant",
+					line: 1,
+					column: 37,
+					endLine: 1,
+					endColumn: 47,
+					suggestions: [
+						{
+							messageId: "removeImportant",
+							output: "a { background: url(!important.png); }",
+						},
+					],
+				},
+			],
+		},
+		{
+			code: 'a { --x: "!important" !important; }',
+			errors: [
+				{
+					messageId: "unexpectedImportant",
+					line: 1,
+					column: 23,
+					endLine: 1,
+					endColumn: 33,
+					suggestions: [
+						{
+							messageId: "removeImportant",
+							output: 'a { --x: "!important"; }',
 						},
 					],
 				},


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What did you do?

```css
/* eslint css/no-important: "error" */

a { content: "!important" !important; }
```

#### What did you expect to happen?

The report to point at the actual `!important` flag.

#### What actually happened?

The rule matched the first `!important` in the declaration text, which is the one inside the string.

#### What is the purpose of this pull request?

This PR fixes `no-important` reporting the wrong location.

#### What changes did you make? (Give an overview)

The flag can only appear after the value, so the search now starts at `node.value.loc.end.offset` instead of the start of the declaration.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of `!important` detection in CSS declarations.
  * Prevented false positives for `!important` text in property names, quoted strings, URLs, and custom property values.
  * Ensured actual trailing `!important` declarations continue to be reported and removed correctly.

* **Tests**
  * Added coverage for quoted strings, URLs, and custom properties containing `!important`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->